### PR TITLE
Default to in-memory DictStorage where feasible

### DIFF
--- a/demo/qasm_single_task.py
+++ b/demo/qasm_single_task.py
@@ -1,4 +1,8 @@
-"""Simple demo to submit a single task (using QASM for testing purposes) and persisting results
+"""Simple demo to submit a single task (using QASM for testing purposes) using
+in-memory storage only (results are not persisted across processes).
+
+For a persistence-enabled version of this demo, see
+qasm_single_task_persistent.py.
 
 NOTE: requires bloqade-circuit[qasm2] to be installed.
 """

--- a/demo/qasm_single_task.py
+++ b/demo/qasm_single_task.py
@@ -41,7 +41,7 @@ def bell():
 
 # 2. Create the task using the device -- optionally set some metadata
 # NOTE: context_name and program_language are set to qasm for testing
-device = QASM2Device(context_name="testbed")
+device = QASM2Device(context_name="gemini-qasm")
 task = device.task(
     kernel=bell, num_shots=2, metadata={"tag": "bell"}, program_language="qasm"
 )  # metadata is completely customizable

--- a/demo/qasm_single_task_persistent.py
+++ b/demo/qasm_single_task_persistent.py
@@ -1,4 +1,4 @@
-"""Simple demo to submit a single task (using QASM for testing purposes) and persisting results
+"""Simple demo to submit a single task (using QASM for testing purposes)
 
 NOTE: requires bloqade-circuit[qasm2] to be installed.
 """
@@ -9,7 +9,7 @@ from bloqade.qasm2.emit import QASM2
 from kirin.ir.method import Method as Method
 
 from bloqade import qasm2
-from bloqade.core.device import Device, Future, Result
+from bloqade.core.device import Device, Future, Result, SQLiteStorage
 from bloqade.core.device.task import SingleKernelTask
 
 
@@ -42,19 +42,25 @@ task = device.task(
     kernel=bell, num_shots=2, metadata={"tag": "bell"}, program_language="qasm"
 )  # metadata is completely customizable
 
+# 3. Submit task -- requires specifying storage
+persistent_storage = SQLiteStorage("qasm_single_task.sql")
+
 # 3a. Dry run
-task.run_async(dry_run=True)
+task.run_async(dry_run=True, storage=persistent_storage)
 
 # 3b. Actually submit
 # NOTE: at this point, a browser window should open to authenticate
-future = task.run_async(dry_run=False)
+future = task.run_async(dry_run=False, storage=persistent_storage)
 
 # NOTE: if you want to resume fetching results, just comment out the line above
 # and use the one below
-# future = Future.from_task_id(task_id=f"{task_id}", context_name="testbed")
+# future = Future.from_storage(storage=persistent_storage, context_name="testbed")
 
 # 4. Wait for completion and get all results
 result = future.result(timeout=80.0)
 
 # 5. Print results -- no logical post-processing can be done here
 print(result.shot_results())
+
+# 6. Finally, close the SQL connection (not strictly necessary, GC will handle it too)
+persistent_storage.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ exclude_also = [
 ]
 
 [tool.pyright]
-ignore = ["demo/qasm_single_task.py"]  # requires bloqade-circuit so pyright will always fail
+ignore = ["demo/qasm_single_task.py", "demo/qasm_single_task_persistent.py"]  # requires bloqade-circuit so pyright will always fail
 
 [tool.pytest.ini_options]
 testpaths = "test/"

--- a/src/bloqade/core/device/future.py
+++ b/src/bloqade/core/device/future.py
@@ -15,6 +15,7 @@ from qlam_core.plugins.tasks.api.tasks_models import (
 from typing_extensions import Self, TypeVar
 
 from .local_storage import (
+    DictStorage,
     ShotFilter,
     ShotResult,
     StorageBackend,
@@ -58,12 +59,13 @@ class Future(AuthMixin, Generic[ResultType]):
     Attributes:
         task_id (str): Backend task ID.
         storage (StorageBackend): Storage backend used for fetched shots and
-            task metadata.
+            task metadata. Defaults to a fresh `DictStorage` (in-memory; not
+            persisted across processes).
         fetch_options (ApiFetchOptions): Pagination and polling options.
     """
 
     task_id: str
-    storage: StorageBackend
+    storage: StorageBackend = field(default_factory=DictStorage)
 
     # API polling behavior
     fetch_options: ApiFetchOptions = ApiFetchOptions()
@@ -379,7 +381,7 @@ class Future(AuthMixin, Generic[ResultType]):
         cls,
         *,
         task_id: str,
-        storage: StorageBackend,
+        storage: StorageBackend | None = None,
         fetch_options: ApiFetchOptions = ApiFetchOptions(),
         context_name: str | None = None,
     ) -> Self:
@@ -391,8 +393,10 @@ class Future(AuthMixin, Generic[ResultType]):
 
         Args:
             task_id (str): Backend task ID.
-            storage (StorageBackend): Storage backend that will receive the task
-                definition and later fetched shots.
+            storage (StorageBackend | None): Storage backend that will receive
+                the task definition and later fetched shots. When None, a fresh
+                `DictStorage` is used (in-memory; not persisted across
+                processes). Defaults to None.
             fetch_options (ApiFetchOptions): Pagination and polling options.
                 Defaults to `ApiFetchOptions()`.
             context_name (str | None): Name of the qlam context used to fetch
@@ -406,6 +410,8 @@ class Future(AuthMixin, Generic[ResultType]):
             ValueError: If `context_name` is None and `cls` has no
                 class-level default.
         """
+        if storage is None:
+            storage = DictStorage()
 
         context_name = cls._resolve_context_name(context_name)
         auth = AuthMixin(context_name=context_name)

--- a/src/bloqade/core/device/future.py
+++ b/src/bloqade/core/device/future.py
@@ -519,6 +519,11 @@ class Future(AuthMixin, Generic[ResultType]):
                     full_subtask_page
                     and len(subtasks) >= self.fetch_options.subtasks_per_fetch
                 )
+
+                self.storage.update_subtasks_completed_date(
+                    task_id=self.task_id, subtasks=subtasks
+                )
+
                 for subtask in subtasks:
                     subtask_status = subtask.get("status", "").upper()
                     if not found_incomplete and subtask_status != "COMPLETED":

--- a/src/bloqade/core/device/local_storage.py
+++ b/src/bloqade/core/device/local_storage.py
@@ -419,7 +419,7 @@ class DictStorage(StorageBackend):
     _metadata: dict = field(init=False, default_factory=dict)
 
     def __repr__(self) -> str:
-        return repr(self._data)
+        return f"DictStorage(num_shots={len(self._data)}, task_ids={self.task_ids()})"
 
     def add_shots(self, shots: Iterable[ShotResult]) -> None:
         """Store shot result rows in memory.

--- a/src/bloqade/core/device/task.py
+++ b/src/bloqade/core/device/task.py
@@ -15,7 +15,7 @@ from qlam_core.plugins.tasks.api.tasks_models import (
 )
 
 from .future import ApiFetchOptions, Future, FutureType
-from .local_storage import StorageBackend
+from .local_storage import DictStorage, StorageBackend
 from .log_info import logger
 from .mixins import AuthMixin
 
@@ -219,7 +219,7 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         self,
         *,
         dry_run: Literal[True],
-        storage: StorageBackend,
+        storage: StorageBackend | None = None,
         fetch_options: ApiFetchOptions = ApiFetchOptions(),
     ) -> None: ...
 
@@ -228,7 +228,7 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         self,
         *,
         dry_run: Literal[False],
-        storage: StorageBackend,
+        storage: StorageBackend | None = None,
         fetch_options: ApiFetchOptions = ApiFetchOptions(),
     ) -> FutureType: ...
 
@@ -236,7 +236,7 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         self,
         *,
         dry_run: bool,
-        storage: StorageBackend,
+        storage: StorageBackend | None = None,
         fetch_options: ApiFetchOptions = ApiFetchOptions(),
     ) -> FutureType | None:
         """Validate the task and either dry-run or submit it.
@@ -244,8 +244,10 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         Keyword Args:
             dry_run (bool): When True, print a summary and return None.
                 When False, submit the task and return a future.
-            storage (StorageBackend): Storage backend that will receive the
-                task definition and later fetched shots.
+            storage (StorageBackend | None): Storage backend that will receive
+                the task definition and later fetched shots. When None, a fresh
+                `DictStorage` is used (in-memory; not persisted across
+                processes). Defaults to None.
             fetch_options (ApiFetchOptions): Pagination and polling options
                 attached to the returned future. Defaults to
                 `ApiFetchOptions()`.
@@ -276,15 +278,16 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         self,
         *,
         task_definition: TaskDefinition,
-        storage: StorageBackend,
+        storage: StorageBackend | None = None,
         fetch_options: ApiFetchOptions = ApiFetchOptions(),
     ) -> FutureType:
         """Submit a prepared task definition and return a future.
 
         Keyword Args:
             task_definition (TaskDefinition): Task definition to submit.
-            storage (StorageBackend): Storage backend that will receive the
-                task definition.
+            storage (StorageBackend | None): Storage backend that will receive
+                the task definition. When None, a fresh `DictStorage` is used
+                (in-memory; not persisted across processes). Defaults to None.
             fetch_options (ApiFetchOptions): Pagination and polling options
                 attached to the returned future. Defaults to
                 `ApiFetchOptions()`.
@@ -295,6 +298,8 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         Raises:
             ValueError: If the backend response is missing a task ID.
         """
+        if storage is None:
+            storage = DictStorage()
 
         self.authenticate()
 

--- a/test/device/test_future.py
+++ b/test/device/test_future.py
@@ -189,6 +189,57 @@ def test_from_task_id_fetches_definition_and_stores_it(monkeypatch):
     assert storage.get_task_creation_time("task-1") == CREATION_TIME
 
 
+def test_future_defaults_to_fresh_dict_storage_per_instance():
+    first = Future(task_id="task-1", context_name="ctx")
+    second = Future(task_id="task-2", context_name="ctx")
+
+    assert isinstance(first.storage, DictStorage)
+    assert isinstance(second.storage, DictStorage)
+    assert first.storage is not second.storage
+
+
+def test_from_task_id_defaults_to_fresh_dict_storage_when_storage_is_none(monkeypatch):
+    task_definition = make_task_definition("from-api")
+
+    class FakeTasksClient:
+        def __init__(self, app_context):
+            self.app_context = app_context
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def get(self, id):
+            return SimpleNamespace(
+                definition="definition-1", created_date=CREATION_TIME
+            )
+
+    class FakeDefinitionsClient:
+        def __init__(self, app_context):
+            self.app_context = app_context
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def get(self, id):
+            return task_definition
+
+    monkeypatch.setattr(future_mod.AuthMixin, "authenticate", lambda auth: None)
+    monkeypatch.setattr(future_mod, "TasksClient", FakeTasksClient)
+    monkeypatch.setattr(future_mod, "DefinitionsClient", FakeDefinitionsClient)
+
+    future = Future.from_task_id(task_id="task-1", context_name="ctx")
+
+    assert isinstance(future.storage, DictStorage)
+    assert future.storage.get_task_definition("task-1") == task_definition
+    assert future.storage.get_task_creation_time("task-1") == CREATION_TIME
+
+
 def test_status_done_and_cancelled_delegate_to_task_status(monkeypatch):
     future = Future(task_id="task-1", storage=DictStorage(), context_name="ctx")
     monkeypatch.setattr(

--- a/test/device/test_future.py
+++ b/test/device/test_future.py
@@ -432,6 +432,70 @@ def test_fetch_subtask_page_parses_results_and_tracks_first_incomplete_page():
     np.testing.assert_array_equal(shots[1].bitstring, np.array([False, True, False]))
 
 
+def test_fetch_subtask_page_persists_subtask_completed_dates():
+    storage = DictStorage()
+    storage.add_task_definition(
+        "task-1",
+        TaskDefinition(
+            program_language="squin",
+            programs=[Program(content="program")],
+            subtasks=[
+                Subtask(program_index=0, num_shots=1),
+                Subtask(program_index=0, num_shots=1),
+                Subtask(program_index=0, num_shots=1),
+            ],
+        ),
+        CREATION_TIME,
+    )
+    future = Future(
+        task_id="task-1",
+        storage=storage,
+        context_name="ctx",
+        fetch_options=ApiFetchOptions(subtasks_per_fetch=10, shots_per_fetch=100),
+    )
+
+    completed_at_0 = datetime(2026, 5, 21, 10, 0, 0, tzinfo=timezone.utc)
+    completed_at_1_iso = "2026-05-21T11:00:00+00:00"
+
+    class FakeResultsClient:
+        def get(self, **kwargs):
+            return {
+                "elements": [
+                    {
+                        "subtasks": [
+                            {
+                                "subtask_index": 0,
+                                "status": "COMPLETED",
+                                "completed_date": completed_at_0,
+                                "shot_results": [],
+                            },
+                            {
+                                "subtask_index": 1,
+                                "status": "COMPLETED",
+                                "completed_date": completed_at_1_iso,
+                                "shot_results": [],
+                            },
+                            {
+                                "subtask_index": 2,
+                                "status": "SCHEDULED",
+                                "completed_date": None,
+                                "shot_results": [],
+                            },
+                        ]
+                    }
+                ]
+            }
+
+    future._fetch_subtask_page(client=FakeResultsClient(), subtask_page=0)  # type: ignore
+
+    subtasks = sorted(
+        storage.get_subtasks(), key=lambda subtask: subtask["subtask_index"]
+    )
+    assert subtasks[0]["completed_date"] == completed_at_0
+    assert subtasks[1]["completed_date"] == datetime.fromisoformat(completed_at_1_iso)
+    assert subtasks[2]["completed_date"] is None
+
+
 def test_cancel_warns_when_backend_cancel_raises(monkeypatch):
     future = Future(task_id="task-1", storage=DictStorage(), context_name="ctx")
     monkeypatch.setattr(future, "authenticate", lambda: None)

--- a/test/device/test_task.py
+++ b/test/device/test_task.py
@@ -253,6 +253,59 @@ def test_submit_task_definition_stores_definition_and_returns_future(monkeypatch
     assert future.context_name == "ctx"
 
 
+def test_run_async_defaults_storage_to_fresh_dict_storage(monkeypatch):
+    task = SingleKernelTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=main,
+        num_shots=1,
+    )
+    submitted = {}
+    sentinel = object()
+
+    def submit_task_definition(**kwargs):
+        submitted.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
+
+    assert task.run_async(dry_run=False) is sentinel
+    assert submitted["storage"] is None
+
+
+def test_submit_task_definition_defaults_to_fresh_dict_storage(monkeypatch):
+    task = SingleKernelTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=main,
+        num_shots=1,
+        future_cls=RecordingFuture,  # type: ignore
+    )
+    task_definition = task.create_task_definition()
+
+    class FakeTasksClient:
+        def __init__(self, app_context):
+            self.app_context = app_context
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def create(self, body):
+            return SimpleNamespace(id="task-created", created_date=CREATION_TIME)
+
+    monkeypatch.setattr(task, "authenticate", lambda: None)
+    monkeypatch.setattr(task_mod, "TasksClient", FakeTasksClient)
+
+    future = task.submit_task_definition(task_definition=task_definition)
+
+    assert isinstance(future.storage, DictStorage)
+    assert future.storage.get_task_definition("task-created") == task_definition
+    assert future.storage.get_task_creation_time("task-created") == CREATION_TIME
+
+
 def test_submit_task_definition_rejects_missing_created_task_id(monkeypatch):
     task = SingleKernelTask(
         context_name="ctx",


### PR DESCRIPTION
After some discussion, decided to add a default that uses in-memory storage. This will make the UX cleaner and users can recover info from the API (and some info is also logged).

Edit: also fix a bug where we never wrote subtask completion dates into storage when fetching.