### PR TITLE
Properly set language version in task definition

### DIFF
--- a/demo/qasm_single_task.py
+++ b/demo/qasm_single_task.py
@@ -20,6 +20,10 @@ from bloqade.core.device.task import SingleKernelTask
 # NOTE: custom task that overrides serialization with QASM2 string emit
 @dataclass
 class QASM2Task(SingleKernelTask):
+    @property
+    def program_language_version(self) -> str:
+        return "2.0"
+
     def serialize_kernel(self, kernel: Method) -> str:
         return QASM2().emit_str(kernel)
 

--- a/demo/qasm_single_task.py
+++ b/demo/qasm_single_task.py
@@ -19,11 +19,11 @@ from bloqade.core.device.task import SingleKernelTask
 
 # NOTE: custom task that overrides serialization with QASM2 string emit
 @dataclass
+@dataclass
 class QASM2Task(SingleKernelTask):
     @property
     def program_language_version(self) -> str:
-        return "2.0"
-
+        return "2.0.0"
     def serialize_kernel(self, kernel: Method) -> str:
         return QASM2().emit_str(kernel)
 

--- a/demo/qasm_single_task.py
+++ b/demo/qasm_single_task.py
@@ -24,6 +24,7 @@ class QASM2Task(SingleKernelTask):
     @property
     def program_language_version(self) -> str:
         return "2.0.0"
+
     def serialize_kernel(self, kernel: Method) -> str:
         return QASM2().emit_str(kernel)
 

--- a/demo/qasm_single_task_persistent.py
+++ b/demo/qasm_single_task_persistent.py
@@ -16,6 +16,10 @@ from bloqade.core.device.task import SingleKernelTask
 # NOTE: custom task that overrides serialization with QASM2 string emit
 @dataclass
 class QASM2Task(SingleKernelTask):
+    @property
+    def program_language_version(self) -> str:
+        return "2.0"
+
     def serialize_kernel(self, kernel: Method) -> str:
         return QASM2().emit_str(kernel)
 

--- a/demo/qasm_single_task_persistent.py
+++ b/demo/qasm_single_task_persistent.py
@@ -20,6 +20,7 @@ class QASM2Task(SingleKernelTask):
     @property
     def program_language_version(self) -> str:
         return "2.0.0"
+
     def serialize_kernel(self, kernel: Method) -> str:
         return QASM2().emit_str(kernel)
 

--- a/demo/qasm_single_task_persistent.py
+++ b/demo/qasm_single_task_persistent.py
@@ -15,11 +15,11 @@ from bloqade.core.device.task import SingleKernelTask
 
 # NOTE: custom task that overrides serialization with QASM2 string emit
 @dataclass
+@dataclass
 class QASM2Task(SingleKernelTask):
     @property
     def program_language_version(self) -> str:
-        return "2.0"
-
+        return "2.0.0"
     def serialize_kernel(self, kernel: Method) -> str:
         return QASM2().emit_str(kernel)
 

--- a/docs/device_workflow.md
+++ b/docs/device_workflow.md
@@ -244,8 +244,10 @@ A `Device` holds a class reference for each task shape it can build
 (`single_kernel_task_cls`, `kernel_batch_task_cls`, `parameter_scan_task_cls`).
 Override the ones you need; the device's `task`, `batch_task`, and
 `parameter_scan` methods will instantiate your subclass. The
-`program_language` argument is just a string recorded on the task
-definition, so set it to whatever the backend expects (here, `"qasm"`):
+`program_language` and `language_version` arguments are recorded on the task
+definition combined as `<program_language>.v<language_version>` (here,
+`"qasm.v0.1.0"`); `language_version` must be a semantic version. Set them to
+whatever the backend expects:
 
 ```python
 from bloqade import qasm2
@@ -269,7 +271,10 @@ result = future.result(timeout=80.0)
 
 Other common extension points on the task itself are
 [`program_language_version`](reference/bloqade/core/device/task.md#bloqade.core.device.task.TaskABC.program_language_version)
-(used by the default Kirin serializer when encoding the kernel),
+(the semantic version used by the default Kirin serializer when encoding the
+kernel — for a static version just pass `language_version=...` to
+`device.task(...)`; override this property only when the version needs
+additional logic),
 [`summary`](reference/bloqade/core/device/task.md#bloqade.core.device.task.TaskABC.summary)
 (text printed on dry-run), and
 [`create_task_definition`](reference/bloqade/core/device/task.md#bloqade.core.device.task.TaskABC.create_task_definition)

--- a/docs/device_workflow.md
+++ b/docs/device_workflow.md
@@ -214,12 +214,15 @@ most use cases. When the backend expects a different program format, or when
 you want to attach extra fields to the submitted task, subclass the relevant
 task type and point the device at it.
 
-As an example, consider a backend that expects QASM2 source. The default
+As an example, consider a backend that expects QASM2 source tagged as
+version `2.0`. The default
 [`SingleKernelTask`](reference/bloqade/core/device/task.md#bloqade.core.device.task.SingleKernelTask)
 would encode the kernel as kirin JSON, which the backend cannot parse.
 Overriding [`serialize_kernel`](reference/bloqade/core/device/task.md#bloqade.core.device.task.TaskABC.serialize_kernel)
-on a subclass and pointing a `Device` subclass at it is enough to switch
-the wire format without changing anything downstream:
+switches the wire format, and overriding
+[`program_language_version`](reference/bloqade/core/device/task.md#bloqade.core.device.task.TaskABC.program_language_version)
+records the right version. Pointing a `Device` subclass at the new task is
+then enough to change everything downstream:
 
 ```python
 from dataclasses import dataclass, field
@@ -230,6 +233,10 @@ from bloqade.core.device.task import SingleKernelTask
 
 @dataclass
 class QASM2Task(SingleKernelTask):
+    @property
+    def program_language_version(self) -> str:
+        return "2.0"
+
     def serialize_kernel(self, kernel: Method) -> str:
         return QASM2().emit_str(kernel)
 
@@ -243,11 +250,13 @@ class QASM2Device(Device):
 A `Device` holds a class reference for each task shape it can build
 (`single_kernel_task_cls`, `kernel_batch_task_cls`, `parameter_scan_task_cls`).
 Override the ones you need; the device's `task`, `batch_task`, and
-`parameter_scan` methods will instantiate your subclass. The
-`program_language` and `language_version` arguments are recorded on the task
-definition combined as `<program_language>.v<language_version>` (here,
-`"qasm.v0.1.0"`); `language_version` must be a semantic version. Set them to
-whatever the backend expects:
+`parameter_scan` methods will instantiate your subclass. The task records its
+language on the definition as `<program_language>.v<program_language_version>`
+— here `"qasm.v2.0"`, since `QASM2Task` pins the version to `"2.0"`.
+`program_language_version` defaults to the `language_version` argument (which
+must be a semantic version); override the property, as above, when a subclass
+should fix or compute the version. Set `program_language` to whatever the
+backend expects:
 
 ```python
 from bloqade import qasm2
@@ -271,10 +280,9 @@ result = future.result(timeout=80.0)
 
 Other common extension points on the task itself are
 [`program_language_version`](reference/bloqade/core/device/task.md#bloqade.core.device.task.TaskABC.program_language_version)
-(the semantic version used by the default Kirin serializer when encoding the
-kernel — for a static version just pass `language_version=...` to
-`device.task(...)`; override this property only when the version needs
-additional logic),
+(the version recorded on the task definition and passed to the default Kirin
+serializer when encoding the kernel — override it as `QASM2Task` does above,
+or pass `language_version=...` to `device.task(...)` for a static version),
 [`summary`](reference/bloqade/core/device/task.md#bloqade.core.device.task.TaskABC.summary)
 (text printed on dry-run), and
 [`create_task_definition`](reference/bloqade/core/device/task.md#bloqade.core.device.task.TaskABC.create_task_definition)

--- a/docs/device_workflow.md
+++ b/docs/device_workflow.md
@@ -215,7 +215,7 @@ you want to attach extra fields to the submitted task, subclass the relevant
 task type and point the device at it.
 
 As an example, consider a backend that expects QASM2 source tagged as
-version `2.0`. The default
+version `2.0.0`. The default
 [`SingleKernelTask`](reference/bloqade/core/device/task.md#bloqade.core.device.task.SingleKernelTask)
 would encode the kernel as kirin JSON, which the backend cannot parse.
 Overriding [`serialize_kernel`](reference/bloqade/core/device/task.md#bloqade.core.device.task.TaskABC.serialize_kernel)
@@ -232,11 +232,11 @@ from bloqade.core.device import Device, Future, Result
 from bloqade.core.device.task import SingleKernelTask
 
 @dataclass
+@dataclass
 class QASM2Task(SingleKernelTask):
     @property
     def program_language_version(self) -> str:
-        return "2.0"
-
+        return "2.0.0"
     def serialize_kernel(self, kernel: Method) -> str:
         return QASM2().emit_str(kernel)
 
@@ -252,7 +252,7 @@ A `Device` holds a class reference for each task shape it can build
 Override the ones you need; the device's `task`, `batch_task`, and
 `parameter_scan` methods will instantiate your subclass. The task records its
 language on the definition as `<program_language>.v<program_language_version>`
-— here `"qasm.v2.0"`, since `QASM2Task` pins the version to `"2.0"`.
+— here "qasm.v2.0.0", since `QASM2Task` pins the version to "2.0.0".
 `program_language_version` defaults to the `language_version` argument (which
 must be a semantic version); override the property, as above, when a subclass
 should fix or compute the version. Set `program_language` to whatever the

--- a/src/bloqade/core/device/device.py
+++ b/src/bloqade/core/device/device.py
@@ -57,6 +57,8 @@ class Device(Generic[FutureType], AuthMixin):
                 task API. Defaults to None.
             program_language (str): Program language to store in the task
                 definition. Defaults to "squin".
+            language_version (str): Semantic version of the program language to
+                store in the task definition. Defaults to "0.1.0".
 
         Returns:
             SingleKernelTask[FutureType]: A task object ready for dry-run or submission.
@@ -94,6 +96,8 @@ class Device(Generic[FutureType], AuthMixin):
                 value to broadcast to every kernel. Defaults to 1.
             program_language (str): Program language to store in the task
                 definition. Defaults to "squin".
+            language_version (str): Semantic version of the program language to
+                store in the task definition. Defaults to "0.1.0".
 
         Returns:
             KernelBatchTask[FutureType]: A batch task object ready for dry-run or
@@ -131,6 +135,8 @@ class Device(Generic[FutureType], AuthMixin):
                 one value to broadcast to every subtask. Defaults to 1.
             program_language (str): Program language to store in the task
                 definition. Defaults to "squin".
+            language_version (str): Semantic version of the program language to
+                store in the task definition. Defaults to "0.1.0".
 
         Returns:
             ParameterScanTask[FutureType]: A parameter-scan task object ready for

--- a/src/bloqade/core/device/device.py
+++ b/src/bloqade/core/device/device.py
@@ -43,6 +43,7 @@ class Device(Generic[FutureType], AuthMixin):
         arguments: dict | None = None,
         metadata: dict | None = None,
         program_language: str = "squin",
+        language_version: str = "0.1.0",
     ) -> SingleKernelTask[FutureType]:
         """Create a task for one kernel.
 
@@ -68,6 +69,7 @@ class Device(Generic[FutureType], AuthMixin):
             arguments=arguments,
             metadata=metadata,
             program_language=program_language,
+            language_version=language_version,
             future_cls=self.future_cls,
         )
 
@@ -78,6 +80,7 @@ class Device(Generic[FutureType], AuthMixin):
         metadata: list[dict[str, Any]] | None = None,
         num_shots: list[int] | int = 1,
         program_language: str = "squin",
+        language_version: str = "0.1.0",
     ) -> KernelBatchTask[FutureType]:
         """Create a task containing one subtask per kernel.
 
@@ -104,6 +107,7 @@ class Device(Generic[FutureType], AuthMixin):
             num_shots=num_shots,
             metadata=metadata,
             program_language=program_language,
+            language_version=language_version,
             future_cls=self.future_cls,
         )
 
@@ -114,6 +118,7 @@ class Device(Generic[FutureType], AuthMixin):
         metadata: list[dict] | None = None,
         num_shots: list[int] | int = 1,
         program_language: str = "squin",
+        language_version: str = "0.1.0",
     ) -> ParameterScanTask[FutureType]:
         """Create a parameter-scan task for one kernel.
 
@@ -139,5 +144,6 @@ class Device(Generic[FutureType], AuthMixin):
             arguments=arguments,
             metadata=metadata,
             program_language=program_language,
+            language_version=language_version,
             future_cls=self.future_cls,
         )

--- a/src/bloqade/core/device/local_storage.py
+++ b/src/bloqade/core/device/local_storage.py
@@ -650,7 +650,7 @@ class DictStorage(StorageBackend):
             return
 
         for subtask in subtasks:
-            completed_date = subtask["completed_date"]
+            completed_date = subtask.get("completed_date")
             if completed_date is None:
                 continue
 

--- a/src/bloqade/core/device/task.py
+++ b/src/bloqade/core/device/task.py
@@ -37,6 +37,7 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
     """
 
     program_language: str
+    language_version: str = "0.1.0"
 
     # NOTE: bound to subclasses of future, so need to ignore the typing issue here
     future_cls: type[FutureType] = Future  # type: ignore
@@ -46,11 +47,10 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         """Program language version recorded when serializing kernels.
 
         Returns:
-            str: Version string, or empty string when not set. Override in
-                subclasses to record a version.
+            str: Version string. Override in subclasses.
         """
-        # NOTE: override this to set versions
-        return ""
+        # NOTE: override this to set versions with additional logic
+        return self.language_version
 
     def serialize_kernel(self, kernel: ir.Method) -> str:
         """Serialize a kernel into a string suitable for the backend.
@@ -208,8 +208,9 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
                 )
             )
 
+        program_language_with_version = f"{self.program_language}.v{self.program_language_version.removeprefix('v')}"
         return TaskDefinition(
-            program_language=self.program_language,
+            program_language=program_language_with_version,
             programs=programs,
             subtasks=subtasks,
         )

--- a/src/bloqade/core/device/task.py
+++ b/src/bloqade/core/device/task.py
@@ -32,6 +32,11 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
     Attributes:
         program_language (str): Program language identifier stored on the
             task definition and used when serializing kernels.
+        language_version (str): Program language version stored on the task
+            definition and used when serializing kernels. Must be a semantic
+            version. Set this directly for a static version, or override the
+            `program_language_version` property if the version needs
+            additional logic. Defaults to "0.1.0".
         future_cls (type[FutureType]): Future class used to construct the
             return value of `submit_task_definition`. Defaults to `Future`.
     """
@@ -46,10 +51,13 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
     def program_language_version(self) -> str:
         """Program language version recorded when serializing kernels.
 
+        Defaults to the `language_version` attribute. Override this property
+        in a subclass if the version needs to be computed with additional
+        logic. The value must be a semantic version.
+
         Returns:
-            str: Version string. Override in subclasses.
+            str: Semantic version string.
         """
-        # NOTE: override this to set versions with additional logic
         return self.language_version
 
     def serialize_kernel(self, kernel: ir.Method) -> str:

--- a/test/device/test_task.py
+++ b/test/device/test_task.py
@@ -48,7 +48,8 @@ class RecordingFuture:
 def test_single_kernel_task_creates_task_definition_with_arguments_and_metadata():
     task = SingleKernelTask(
         context_name="ctx",
-        program_language="flair.v1",
+        program_language="flair",
+        language_version="1",
         kernel=main,
         arguments={"theta": 1.5},
         metadata={"purpose": "unit-test"},


### PR DESCRIPTION
* Adds a proper semantic version to the `program_language` set in the `TaskDefinition` before submitting it.
* Also, adds a public attribute `language_version` on `TaskABC`, which can be passed in as kwarg. The property `program_language_version` is still there so this change is non-breaking, but it's just a thin wrapper around `language_version`.
* Fix a bug that lead to `KeyError` in `DictStorage` when updating `completed_date` of subtasks.