### PR TITLE
Refresh authentication on 403

### DIFF
--- a/src/bloqade/core/device/future.py
+++ b/src/bloqade/core/device/future.py
@@ -4,6 +4,7 @@ from typing import Any, Generic
 from warnings import warn
 
 import numpy as np
+from qlam_core.errors import APIError
 from qlam_core.plugins.compilations.api import CompilationsClient
 from qlam_core.plugins.definitions.api.client import DefinitionsClient
 from qlam_core.plugins.results.api.client import ResultsClient
@@ -94,7 +95,9 @@ class Future(AuthMixin, Generic[ResultType]):
         with TasksClient(self.app_context) as client:
             # NOTE: typing issue in qlam-core
             # every client is BaseRestApi, which doesn't have get, but it actually does
-            task = client.get(id=self.task_id)  # type: ignore
+            task = self.call_with_auth_refresh(
+                lambda: client.get(id=self.task_id)  # type: ignore
+            )
             logger.info(
                 f"Fetched task with id {self.task_id}. Current status: {task.task_status}"
             )
@@ -117,7 +120,9 @@ class Future(AuthMixin, Generic[ResultType]):
             compilation_id = self.get_task().compilation_id
 
         with CompilationsClient(self.app_context) as client:
-            return client.get(id=compilation_id)  # type: ignore
+            return self.call_with_auth_refresh(
+                lambda: client.get(id=compilation_id)  # type: ignore
+            )
 
     def fetch(self) -> None:
         """Fetch currently available shot results into this future's storage.
@@ -133,9 +138,11 @@ class Future(AuthMixin, Generic[ResultType]):
 
         with ResultsClient(self.app_context) as client:
             while not done:
-                done = self._fetch_subtask_page(
-                    client=client,  # type: ignore
-                    subtask_page=subtask_page,
+                done = self.call_with_auth_refresh(
+                    lambda page=subtask_page: self._fetch_subtask_page(
+                        client=client,  # type: ignore
+                        subtask_page=page,
+                    )
                 )
 
                 subtask_page += 1
@@ -169,7 +176,18 @@ class Future(AuthMixin, Generic[ResultType]):
         with TasksClient(self.app_context) as client:
             try:
                 # NOTE: typing issue because client is seen as BaseClient instead of TaskClient
-                return client.cancel(id=self.task_id)  # type: ignore
+                return self.call_with_auth_refresh(
+                    lambda: client.cancel(id=self.task_id)  # type: ignore
+                )
+            except APIError as e:
+                if e.status_code == 403:
+                    warn(
+                        f"Could not cancel task with ID {self.task_id}: permission denied (403) and credential refresh did not restore access."
+                    )
+                    return
+                warn(
+                    f"API error encountered when trying to cancel task with ID {self.task_id}: {str(repr(e))}"
+                )
             except Exception as e:
                 warn(
                     f"Exception encountered when trying to cancel task with ID {self.task_id}: {str(repr(e))}"
@@ -417,11 +435,15 @@ class Future(AuthMixin, Generic[ResultType]):
         auth = AuthMixin(context_name=context_name)
         auth.authenticate()
         with TasksClient(auth.app_context) as client:
-            task = client.get(id=task_id)  # type: ignore
+            task = auth.call_with_auth_refresh(
+                lambda: client.get(id=task_id)  # type: ignore
+            )
 
         # fetch subtasks for metadata
         with DefinitionsClient(auth.app_context) as client:
-            task_def = client.get(id=task.definition_id)  # type: ignore
+            task_def = auth.call_with_auth_refresh(
+                lambda: client.get(id=task.definition_id)  # type: ignore
+            )
 
         storage.add_task_definition(
             task_id, task_definition=task_def, creation_time=task.created_date

--- a/src/bloqade/core/device/future.py
+++ b/src/bloqade/core/device/future.py
@@ -4,7 +4,6 @@ from typing import Any, Generic
 from warnings import warn
 
 import numpy as np
-from qlam_core.errors import APIError
 from qlam_core.plugins.compilations.api import CompilationsClient
 from qlam_core.plugins.definitions.api.client import DefinitionsClient
 from qlam_core.plugins.results.api.client import ResultsClient
@@ -178,15 +177,6 @@ class Future(AuthMixin, Generic[ResultType]):
                 # NOTE: typing issue because client is seen as BaseClient instead of TaskClient
                 return self.call_with_auth_refresh(
                     lambda: client.cancel(id=self.task_id)  # type: ignore
-                )
-            except APIError as e:
-                if e.status_code == 403:
-                    warn(
-                        f"Could not cancel task with ID {self.task_id}: permission denied (403) and credential refresh did not restore access."
-                    )
-                    return
-                warn(
-                    f"API error encountered when trying to cancel task with ID {self.task_id}: {str(repr(e))}"
                 )
             except Exception as e:
                 warn(

--- a/src/bloqade/core/device/mixins.py
+++ b/src/bloqade/core/device/mixins.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass
+from typing import Callable, TypeVar
 
 from qlam_core.auth.client import AuthClient
 from qlam_core.common import AppContext
+from qlam_core.errors import APIError
+
+T = TypeVar("T")
 
 
 @dataclass(kw_only=True)
@@ -37,3 +41,37 @@ class AuthMixin:
                 return
 
             return client.login()
+
+    def call_with_auth_refresh(self, fn: Callable[[], T]) -> T:
+        """Run a qlam API call, refreshing credentials once on a 403.
+
+        If `fn` raises an `APIError` with status 403, a best-effort
+        non-interactive credential refresh is attempted via `AuthClient`.
+        When the refresh updates at least one provider's credentials, `fn`
+        is invoked again. Any other error, or a refresh that produces no
+        fresh credentials, propagates the original exception.
+
+        Only one retry is attempted; a second 403 is re-raised.
+
+        Args:
+            fn (Callable[[], T]): Zero-argument callable that performs the
+                qlam API call.
+
+        Returns:
+            T: The value returned by `fn`.
+
+        Raises:
+            APIError: When `fn` raises an `APIError` whose status is not 403,
+                when refresh produces no fresh credentials, or when the retry
+                also fails.
+        """
+        try:
+            return fn()
+        except APIError as e:
+            if e.status_code != 403:
+                raise
+            with AuthClient(self.app_context) as client:
+                refresh_results = client.refresh_credentials()
+            if not any(refresh_results.values()):
+                raise
+            return fn()

--- a/src/bloqade/core/device/mixins.py
+++ b/src/bloqade/core/device/mixins.py
@@ -43,15 +43,16 @@ class AuthMixin:
             return client.login()
 
     def call_with_auth_refresh(self, fn: Callable[[], T]) -> T:
-        """Run a qlam API call, refreshing credentials once on a 403.
+        """Run a qlam API call, refreshing credentials once on a 401 or 403.
 
-        If `fn` raises an `APIError` with status 403, a best-effort
-        non-interactive credential refresh is attempted via `AuthClient`.
-        When the refresh updates at least one provider's credentials, `fn`
-        is invoked again. Any other error, or a refresh that produces no
-        fresh credentials, propagates the original exception.
+        If `fn` raises an `APIError` with status 401 (token expired) or 403
+        (access denied), a best-effort non-interactive credential refresh is
+        attempted via `AuthClient`. When the refresh updates at least one
+        provider's credentials, `fn` is invoked again. Any other error, or a
+        refresh that produces no fresh credentials, propagates the original
+        exception.
 
-        Only one retry is attempted; a second 403 is re-raised.
+        Only one retry is attempted; a second 401/403 is re-raised.
 
         Args:
             fn (Callable[[], T]): Zero-argument callable that performs the
@@ -61,14 +62,14 @@ class AuthMixin:
             T: The value returned by `fn`.
 
         Raises:
-            APIError: When `fn` raises an `APIError` whose status is not 403,
-                when refresh produces no fresh credentials, or when the retry
-                also fails.
+            APIError: When `fn` raises an `APIError` whose status is neither
+                401 nor 403, when refresh produces no fresh credentials, or
+                when the retry also fails.
         """
         try:
             return fn()
         except APIError as e:
-            if e.status_code != 403:
+            if e.status_code not in (401, 403):
                 raise
             with AuthClient(self.app_context) as client:
                 refresh_results = client.refresh_credentials()

--- a/src/bloqade/core/device/task.py
+++ b/src/bloqade/core/device/task.py
@@ -314,7 +314,9 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
 
         task_request = TaskCreationRequest(root=task_definition)
         with TasksClient(self.app_context) as tasks_client:
-            created_task = tasks_client.create(body=task_request)  # type: ignore
+            created_task = self.call_with_auth_refresh(
+                lambda: tasks_client.create(body=task_request)  # type: ignore
+            )
 
         task_id = created_task.id
 

--- a/test/device/fixtures/remote.py
+++ b/test/device/fixtures/remote.py
@@ -454,6 +454,32 @@ class FakeCompilationsClient(_RecordingContextManager):
         return self.get_return
 
 
+class FakeAuthClient(_RecordingContextManager):
+    """Replaces `qlam_core.auth.client.AuthClient` in tests.
+
+    Records each `refresh_credentials` call and returns the configured
+    mapping. The default `refresh_result={"qlam": True}` simulates a
+    successful refresh; pass `{"qlam": False}` (or an empty dict) to
+    simulate a refresh that produced no fresh credentials.
+    """
+
+    def __init__(
+        self,
+        app_context: Any = None,
+        *,
+        refresh_result: dict[str, bool] | None = None,
+    ) -> None:
+        _RecordingContextManager.__init__(self)
+        self.app_context = app_context
+        self.refresh_result = (
+            {"qlam": True} if refresh_result is None else refresh_result
+        )
+
+    def refresh_credentials(self, provider: str | None = None, *, force: bool = False):
+        self._record("refresh_credentials", provider=provider, force=force)
+        return self.refresh_result
+
+
 class FakeResultsClient(_RecordingContextManager):
     """Replaces `qlam_core.plugins.results.api.client.ResultsClient`.
 

--- a/test/device/test_future.py
+++ b/test/device/test_future.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+from qlam_core.errors import APIError
 from qlam_core.plugins.tasks.api.tasks_models import TaskStatus
 
 from bloqade.core.device.future import ApiFetchOptions, Future
@@ -16,6 +17,7 @@ from bloqade.core.device.result import Result
 from .fixtures import local, remote
 
 future_mod = importlib.import_module("bloqade.core.device.future")
+mixins_mod = importlib.import_module("bloqade.core.device.mixins")
 
 CREATION_TIME = local.CREATION_TIME
 
@@ -567,3 +569,56 @@ def test_get_compilation_uses_task_compilation_id_when_omitted(monkeypatch):
     assert future.get_compilation() is returned_compilation
     assert authenticated == [True]
     assert client.calls == [("get", {"id": str(returned_compilation.id)})]
+
+
+def test_cancel_warns_when_403_persists_after_refresh(monkeypatch, recwarn):
+    future = Future(task_id="task-1", storage=DictStorage(), context_name="ctx")
+
+    def cancel_call(id):  # noqa: A002
+        raise APIError(message="permission denied", status_code=403)
+
+    tasks_client = remote.FakeTasksClient()
+    monkeypatch.setattr(tasks_client, "cancel", cancel_call)
+    auth_client = remote.FakeAuthClient(refresh_result={"qlam": False})
+
+    monkeypatch.setattr(future_mod.AuthMixin, "authenticate", lambda auth: None)
+    monkeypatch.setattr(future_mod, "TasksClient", lambda app_context: tasks_client)
+    monkeypatch.setattr(mixins_mod, "AuthClient", lambda app_context: auth_client)
+
+    assert future.cancel() is None
+    messages = [str(w.message) for w in recwarn.list]
+    assert any("permission denied (403)" in m for m in messages)
+    assert [name for name, _ in auth_client.calls] == ["refresh_credentials"]
+
+
+def test_fetch_retries_only_the_failing_page_on_403(monkeypatch):
+    future = Future(task_id="task-1", storage=DictStorage(), context_name="ctx")
+
+    class _DummyResultsClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    attempts = []
+
+    def fake_fetch_subtask_page(self, *, client, subtask_page):
+        attempts.append(subtask_page)
+        if subtask_page == 1 and attempts.count(1) == 1:
+            raise APIError(message="permission denied", status_code=403)
+        return subtask_page >= 2
+
+    auth_client = remote.FakeAuthClient(refresh_result={"qlam": True})
+
+    monkeypatch.setattr(future_mod.AuthMixin, "authenticate", lambda auth: None)
+    monkeypatch.setattr(
+        future_mod, "ResultsClient", lambda app_context: _DummyResultsClient()
+    )
+    monkeypatch.setattr(Future, "_fetch_subtask_page", fake_fetch_subtask_page)
+    monkeypatch.setattr(mixins_mod, "AuthClient", lambda app_context: auth_client)
+
+    future.fetch()
+
+    assert attempts == [0, 1, 1, 2]
+    assert [name for name, _ in auth_client.calls] == ["refresh_credentials"]

--- a/test/device/test_future.py
+++ b/test/device/test_future.py
@@ -571,26 +571,6 @@ def test_get_compilation_uses_task_compilation_id_when_omitted(monkeypatch):
     assert client.calls == [("get", {"id": str(returned_compilation.id)})]
 
 
-def test_cancel_warns_when_403_persists_after_refresh(monkeypatch, recwarn):
-    future = Future(task_id="task-1", storage=DictStorage(), context_name="ctx")
-
-    def cancel_call(id):  # noqa: A002
-        raise APIError(message="permission denied", status_code=403)
-
-    tasks_client = remote.FakeTasksClient()
-    monkeypatch.setattr(tasks_client, "cancel", cancel_call)
-    auth_client = remote.FakeAuthClient(refresh_result={"qlam": False})
-
-    monkeypatch.setattr(future_mod.AuthMixin, "authenticate", lambda auth: None)
-    monkeypatch.setattr(future_mod, "TasksClient", lambda app_context: tasks_client)
-    monkeypatch.setattr(mixins_mod, "AuthClient", lambda app_context: auth_client)
-
-    assert future.cancel() is None
-    messages = [str(w.message) for w in recwarn.list]
-    assert any("permission denied (403)" in m for m in messages)
-    assert [name for name, _ in auth_client.calls] == ["refresh_credentials"]
-
-
 def test_fetch_retries_only_the_failing_page_on_403(monkeypatch):
     future = Future(task_id="task-1", storage=DictStorage(), context_name="ctx")
 

--- a/test/device/test_mixins.py
+++ b/test/device/test_mixins.py
@@ -53,6 +53,23 @@ def test_call_with_auth_refresh_retries_after_successful_refresh(monkeypatch):
     assert [name for name, _ in fake.calls] == ["refresh_credentials"]
 
 
+def test_call_with_auth_refresh_retries_after_successful_refresh_on_401(monkeypatch):
+    auth = AuthMixin(context_name="ctx")
+    fake = remote.FakeAuthClient(refresh_result={"qlam": True})
+    monkeypatch.setattr(mixins_mod, "AuthClient", lambda app_context: fake)
+    invocations = []
+
+    def fn():
+        invocations.append(None)
+        if len(invocations) == 1:
+            raise APIError(message="token expired", status_code=401)
+        return "refreshed"
+
+    assert auth.call_with_auth_refresh(fn) == "refreshed"
+    assert len(invocations) == 2
+    assert [name for name, _ in fake.calls] == ["refresh_credentials"]
+
+
 def test_call_with_auth_refresh_reraises_when_refresh_yields_no_credentials(
     monkeypatch,
 ):

--- a/test/device/test_mixins.py
+++ b/test/device/test_mixins.py
@@ -1,0 +1,91 @@
+import importlib
+
+import pytest
+from qlam_core.errors import APIError
+
+from bloqade.core.device.mixins import AuthMixin
+
+from .fixtures import remote
+
+mixins_mod = importlib.import_module("bloqade.core.device.mixins")
+
+
+def test_call_with_auth_refresh_returns_value_and_does_not_refresh_on_success(
+    monkeypatch,
+):
+    auth = AuthMixin(context_name="ctx")
+    fake = remote.FakeAuthClient()
+    monkeypatch.setattr(mixins_mod, "AuthClient", lambda app_context: fake)
+
+    assert auth.call_with_auth_refresh(lambda: "ok") == "ok"
+    assert fake.calls == []
+
+
+def test_call_with_auth_refresh_reraises_non_403_without_refresh(monkeypatch):
+    auth = AuthMixin(context_name="ctx")
+    fake = remote.FakeAuthClient()
+    monkeypatch.setattr(mixins_mod, "AuthClient", lambda app_context: fake)
+
+    def fn():
+        raise APIError(message="server error", status_code=500)
+
+    with pytest.raises(APIError) as excinfo:
+        auth.call_with_auth_refresh(fn)
+
+    assert excinfo.value.status_code == 500
+    assert fake.calls == []
+
+
+def test_call_with_auth_refresh_retries_after_successful_refresh(monkeypatch):
+    auth = AuthMixin(context_name="ctx")
+    fake = remote.FakeAuthClient(refresh_result={"qlam": True})
+    monkeypatch.setattr(mixins_mod, "AuthClient", lambda app_context: fake)
+    invocations = []
+
+    def fn():
+        invocations.append(None)
+        if len(invocations) == 1:
+            raise APIError(message="permission denied", status_code=403)
+        return "refreshed"
+
+    assert auth.call_with_auth_refresh(fn) == "refreshed"
+    assert len(invocations) == 2
+    assert [name for name, _ in fake.calls] == ["refresh_credentials"]
+
+
+def test_call_with_auth_refresh_reraises_when_refresh_yields_no_credentials(
+    monkeypatch,
+):
+    auth = AuthMixin(context_name="ctx")
+    fake = remote.FakeAuthClient(refresh_result={"qlam": False})
+    monkeypatch.setattr(mixins_mod, "AuthClient", lambda app_context: fake)
+    invocations = []
+
+    def fn():
+        invocations.append(None)
+        raise APIError(message="permission denied", status_code=403)
+
+    with pytest.raises(APIError) as excinfo:
+        auth.call_with_auth_refresh(fn)
+
+    assert excinfo.value.status_code == 403
+    assert len(invocations) == 1
+    assert [name for name, _ in fake.calls] == ["refresh_credentials"]
+
+
+def test_call_with_auth_refresh_only_retries_once(monkeypatch):
+    auth = AuthMixin(context_name="ctx")
+    fake = remote.FakeAuthClient(refresh_result={"qlam": True})
+    monkeypatch.setattr(mixins_mod, "AuthClient", lambda app_context: fake)
+    invocations = []
+
+    def fn():
+        invocations.append(None)
+        raise APIError(message="still denied", status_code=403)
+
+    with pytest.raises(APIError) as excinfo:
+        auth.call_with_auth_refresh(fn)
+
+    assert excinfo.value.status_code == 403
+    assert len(invocations) == 2
+    assert [name for name, _ in fake.calls] == ["refresh_credentials"]

--- a/test/device/test_task.py
+++ b/test/device/test_task.py
@@ -3,6 +3,7 @@ import json
 
 import pytest
 from kirin.prelude import basic_no_opt
+from qlam_core.errors import APIError
 from qlam_core.plugins.tasks.api.tasks_models import TaskStatus
 
 from bloqade.core.device.future import ApiFetchOptions
@@ -16,6 +17,7 @@ from bloqade.core.device.task import (
 from .fixtures import local, remote
 
 task_mod = importlib.import_module("bloqade.core.device.task")
+mixins_mod = importlib.import_module("bloqade.core.device.mixins")
 
 CREATION_TIME = local.CREATION_TIME
 
@@ -320,3 +322,44 @@ def test_submit_task_definition_rejects_missing_created_task_id(monkeypatch):
             task_definition=task.create_task_definition(),
             storage=DictStorage(),
         )
+
+
+def test_submit_task_definition_retries_on_403_after_refresh(monkeypatch):
+    task = SingleKernelTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=main,
+        num_shots=1,
+        future_cls=RecordingFuture,  # type: ignore
+    )
+    task_definition = task.create_task_definition()
+    created_task = remote.make_task(
+        id="task-x",
+        task_status=TaskStatus.CREATED,
+        created_date=CREATION_TIME,
+    )
+
+    invocations = []
+
+    def create_return(body):
+        invocations.append(body)
+        if len(invocations) == 1:
+            raise APIError(message="permission denied", status_code=403)
+        return created_task
+
+    client = remote.FakeTasksClient(create_return=create_return)
+    auth_client = remote.FakeAuthClient(refresh_result={"qlam": True})
+
+    monkeypatch.setattr(task, "authenticate", lambda: None)
+    monkeypatch.setattr(task_mod, "TasksClient", lambda app_context: client)
+    monkeypatch.setattr(mixins_mod, "AuthClient", lambda app_context: auth_client)
+
+    future = task.submit_task_definition(
+        task_definition=task_definition,
+        storage=DictStorage(),
+    )
+
+    assert future.task_id == "task-x"
+    assert len(invocations) == 2
+    assert [name for name, _ in client.calls] == ["create", "create"]
+    assert [name for name, _ in auth_client.calls] == ["refresh_credentials"]


### PR DESCRIPTION
Scenario:
* Your permissions change while you are authenticated.
* Before this change, you'd still see a 403 until the cached on-disk credentials are removed or expire.
* With this change, we silently refresh the credentials once after a 403, so the user should not see this.