### PR TITLE
feat!: added shots arg to run_async

### DIFF
--- a/demo/qasm_single_task.py
+++ b/demo/qasm_single_task.py
@@ -49,15 +49,15 @@ def bell():
 # NOTE: context_name and program_language are set to qasm for testing
 device = QASM2Device(context_name="gemini-qasm")
 task = device.task(
-    kernel=bell, num_shots=2, metadata={"tag": "bell"}, program_language="qasm"
+    kernel=bell, metadata={"tag": "bell"}, program_language="qasm"
 )  # metadata is completely customizable
 
 # 3a. Dry run
-task.run_async(dry_run=True)
+task.run_async(shots=2)
 
 # 3b. Actually submit
 # NOTE: at this point, a browser window should open to authenticate
-future = task.run_async(dry_run=False)
+future = task.run_async(dry_run=False, shots=2)
 
 # NOTE: if you want to resume fetching results, just comment out the line above
 # and use the one below

--- a/demo/qasm_single_task_persistent.py
+++ b/demo/qasm_single_task_persistent.py
@@ -43,18 +43,18 @@ def bell():
 # NOTE: context_name and program_language are set to qasm for testing
 device = QASM2Device(context_name="testbed")
 task = device.task(
-    kernel=bell, num_shots=2, metadata={"tag": "bell"}, program_language="qasm"
+    kernel=bell, metadata={"tag": "bell"}, program_language="qasm"
 )  # metadata is completely customizable
 
 # 3. Submit task -- requires specifying storage
 persistent_storage = SQLiteStorage("qasm_single_task.sql")
 
 # 3a. Dry run
-task.run_async(dry_run=True, storage=persistent_storage)
+task.run_async(shots=2, storage=persistent_storage)
 
 # 3b. Actually submit
 # NOTE: at this point, a browser window should open to authenticate
-future = task.run_async(dry_run=False, storage=persistent_storage)
+future = task.run_async(dry_run=False, shots=2, storage=persistent_storage)
 
 # NOTE: if you want to resume fetching results, just comment out the line above
 # and use the one below

--- a/demo/qasm_single_task_simpler_serialization.py
+++ b/demo/qasm_single_task_simpler_serialization.py
@@ -39,7 +39,6 @@ def bell():
 device = Device(context_name="gemini-qasm")
 task = device.task(
     kernel=bell,
-    num_shots=2,
     metadata={"tag": "bell"},
     program_language="qasm",
     language_version="2.0.0",
@@ -47,11 +46,11 @@ task = device.task(
 )  # metadata is completely customizable
 
 # 3a. Dry run
-task.run_async(dry_run=True)
+task.run_async(shots=2)
 
 # 3b. Actually submit
 # NOTE: at this point, a browser window should open to authenticate
-future = task.run_async(dry_run=False)
+future = task.run_async(dry_run=False, shots=2)
 
 # NOTE: if you want to resume fetching results, just comment out the line above
 # and use the one below

--- a/docs/device_workflow.md
+++ b/docs/device_workflow.md
@@ -18,12 +18,13 @@ anything itself; it builds task objects via [`Device.task`](reference/bloqade/co
 [`Device.batch_task`](reference/bloqade/core/device/device.md#bloqade.core.device.device.Device.batch_task),
 and [`Device.parameter_scan`](reference/bloqade/core/device/device.md#bloqade.core.device.device.Device.parameter_scan).
 
-**Task.** Bundles one or more kernels with per-subtask metadata, arguments,
-and shot counts. A task is what actually gets sent to the backend. Calling
-[`run_async(dry_run=True)`](reference/bloqade/core/device/task.md#bloqade.core.device.task.TaskABC.run_async)
-validates the task and prints a summary without submitting;
-`run_async(dry_run=False)` serializes the kernels, submits them, and returns
-a `Future`. The concrete task shapes are
+**Task.** Bundles one or more kernels with per-subtask metadata and
+arguments. Supply shot counts when creating a QLAM definition or override the
+default of one shot when executing a task.
+[`run_async()`](reference/bloqade/core/device/task.md#bloqade.core.device.task.TaskABC.run_async)
+defaults to a one-shot dry run and prints a summary without submitting;
+`run_async(dry_run=False, shots=...)` serializes the kernels, submits them,
+and returns a `Future`. The concrete task shapes are
 [`SingleKernelTask`](reference/bloqade/core/device/task.md#bloqade.core.device.task.SingleKernelTask),
 [`KernelBatchTask`](reference/bloqade/core/device/task.md#bloqade.core.device.task.KernelBatchTask),
 and [`ParameterScanTask`](reference/bloqade/core/device/task.md#bloqade.core.device.task.ParameterScanTask),
@@ -73,16 +74,15 @@ def bell():
 device = Device(context_name="my-context")
 task = device.task(
     kernel=bell,
-    num_shots=2,
     metadata={"tag": "bell"},      # metadata is arbitrary user JSON
     program_language="squin",
 )
 
 # 3a. Dry-run first to see what would be submitted.
-task.run_async(dry_run=True)
+task.run_async(shots=2)
 
 # 3b. Submit. The first call triggers browser-based authentication.
-future = task.run_async(dry_run=False)
+future = task.run_async(dry_run=False, shots=2)
 
 # 4. Wait for completion and read shot bitstrings.
 result = future.result(timeout=80.0)
@@ -112,7 +112,7 @@ instead to keep everything on disk and resume work in a later session:
 from bloqade.core.device import SQLiteStorage
 
 storage = SQLiteStorage("results.sql")
-future = task.run_async(dry_run=False, storage=storage)
+future = task.run_async(dry_run=False, shots=2, storage=storage)
 result = future.result(timeout=80.0)
 
 storage.close()  # optional; GC will also close it
@@ -270,11 +270,10 @@ def bell():
 device = QASM2Device(context_name="my-qasm-context")
 task = device.task(            # returns a QASM2Task instance
     kernel=bell,
-    num_shots=2,
     metadata={"tag": "bell"},
     program_language="qasm",
 )
-future = task.run_async(dry_run=False)
+future = task.run_async(dry_run=False, shots=2)
 result = future.result(timeout=80.0)
 ```
 

--- a/src/bloqade/core/device/device.py
+++ b/src/bloqade/core/device/device.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Generic, cast
+from typing import Generic, cast
 
 from kirin import ir
 from kirin.serialization import JSONSerializer
@@ -63,7 +63,6 @@ class Device(Generic[FutureType], AuthMixin):
     def task(
         self,
         kernel: ir.Method,
-        num_shots: int = 1,
         arguments: dict | None = None,
         metadata: dict | None = None,
         program_language: str = "squin",
@@ -74,7 +73,6 @@ class Device(Generic[FutureType], AuthMixin):
 
         Args:
             kernel (ir.Method): The kernel to execute.
-            num_shots (int): Number of shots to run for the kernel. Defaults to 1.
             arguments (dict | None): Argument dictionary for the kernel.
                 Defaults to None.
             metadata (dict | None): Metadata for the single subtask. When
@@ -95,7 +93,6 @@ class Device(Generic[FutureType], AuthMixin):
         return self.single_kernel_task_cls(
             context_name=self.context_name,
             kernel=kernel,
-            num_shots=num_shots,
             arguments=arguments,
             metadata=metadata,
             program_language=program_language,
@@ -108,8 +105,7 @@ class Device(Generic[FutureType], AuthMixin):
         self,
         kernels: list[ir.Method],
         arguments: list[dict] | None = None,
-        metadata: list[dict[str, Any]] | None = None,
-        num_shots: list[int] | int = 1,
+        metadata: list[dict] | None = None,
         program_language: str = "squin",
         language_version: str = "0.1.0",
         kernel_serializer: KernelSerializer | None = None,
@@ -120,10 +116,8 @@ class Device(Generic[FutureType], AuthMixin):
             kernels (list[ir.Method]): Kernels to execute.
             arguments (list[dict] | None): Per-kernel argument dictionaries.
                 Defaults to None.
-            metadata (list[dict[str, Any]] | None): Per-kernel metadata
+            metadata (list[dict] | None): Per-kernel metadata
                 dictionaries. Defaults to None.
-            num_shots (list[int] | int): Shot count for each kernel, or one
-                value to broadcast to every kernel. Defaults to 1.
             program_language (str): Program language to store in the task
                 definition. Defaults to "squin".
             language_version (str): Semantic version of the program language to
@@ -141,7 +135,6 @@ class Device(Generic[FutureType], AuthMixin):
             context_name=self.context_name,
             kernels=kernels,
             arguments=arguments,
-            num_shots=num_shots,
             metadata=metadata,
             program_language=program_language,
             language_version=language_version,
@@ -154,7 +147,6 @@ class Device(Generic[FutureType], AuthMixin):
         kernel: ir.Method,
         arguments: list[dict],
         metadata: list[dict] | None = None,
-        num_shots: list[int] | int = 1,
         program_language: str = "squin",
         language_version: str = "0.1.0",
         kernel_serializer: KernelSerializer | None = None,
@@ -166,8 +158,6 @@ class Device(Generic[FutureType], AuthMixin):
             arguments (list[dict]): Argument dictionaries, one per subtask.
             metadata (list[dict] | None): Metadata dictionaries, one per
                 subtask. Defaults to None.
-            num_shots (list[int] | int): Shot count for each parameter set, or
-                one value to broadcast to every subtask. Defaults to 1.
             program_language (str): Program language to store in the task
                 definition. Defaults to "squin".
             language_version (str): Semantic version of the program language to
@@ -184,7 +174,6 @@ class Device(Generic[FutureType], AuthMixin):
         return self.parameter_scan_task_cls(
             context_name=self.context_name,
             kernel=kernel,
-            num_shots=num_shots,
             arguments=arguments,
             metadata=metadata,
             program_language=program_language,

--- a/src/bloqade/core/device/device.py
+++ b/src/bloqade/core/device/device.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Generic, cast
+from typing import Any, Generic, cast
 
 from kirin import ir
 from kirin.serialization import JSONSerializer
@@ -105,7 +105,7 @@ class Device(Generic[FutureType], AuthMixin):
         self,
         kernels: list[ir.Method],
         arguments: list[dict] | None = None,
-        metadata: list[dict] | None = None,
+        metadata: list[dict[str, Any]] | None = None,
         program_language: str = "squin",
         language_version: str = "0.1.0",
         kernel_serializer: KernelSerializer | None = None,
@@ -116,7 +116,7 @@ class Device(Generic[FutureType], AuthMixin):
             kernels (list[ir.Method]): Kernels to execute.
             arguments (list[dict] | None): Per-kernel argument dictionaries.
                 Defaults to None.
-            metadata (list[dict] | None): Per-kernel metadata
+            metadata (list[dict[str, Any]] | None): Per-kernel metadata
                 dictionaries. Defaults to None.
             program_language (str): Program language to store in the task
                 definition. Defaults to "squin".

--- a/src/bloqade/core/device/task.py
+++ b/src/bloqade/core/device/task.py
@@ -135,7 +135,7 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         """Validate that task field lengths match the subtask count.
 
         Raises:
-            ValueError: If arguments or metadata length differs from
+            ValueError: If argument or metadata length differs from
                 `num_subtasks`.
         """
         arguments = self.get_arguments()
@@ -148,12 +148,6 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         if metadata is not None and len(metadata) != self.num_subtasks:
             raise ValueError(
                 f"Length mismatch: got {len(metadata)} sets of metadata for {self.num_subtasks} subtasks!"
-            )
-
-        num_shots = self.get_num_shots()
-        if len(num_shots) != self.num_subtasks:
-            raise ValueError(
-                f"Length mismatch: got {len(num_shots)} shot counts for {self.num_subtasks} subtasks!"
             )
 
     @abstractmethod
@@ -185,15 +179,6 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         """
         ...
 
-    @abstractmethod
-    def get_num_shots(self) -> list[int]:
-        """Return the per-subtask shot counts.
-
-        Returns:
-            list[int]: Shot count for each subtask, in subtask order.
-        """
-        ...
-
     def programs(self) -> list[Program]:
         """Build the program list for the task definition.
 
@@ -221,18 +206,31 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         """
         return i
 
-    def create_task_definition(self) -> TaskDefinition:
+    def create_task_definition(self, *, num_shots: int | list[int]) -> TaskDefinition:
         """Build a `TaskDefinition` from this task's kernels and subtasks.
 
-        Override this method directly if your use-case doesn't fit the API
-        contract.
+        Every QLAM subtask requires a concrete shot count, so callers must
+        provide one value to broadcast or one value per subtask. Override this
+        method directly if your use-case doesn't fit the API contract.
+
+        Keyword Args:
+            num_shots (int | list[int]): Shot count for every subtask, or one
+                count per subtask.
 
         Returns:
             TaskDefinition: Definition ready to be submitted.
         """
         programs = self.programs()
 
-        num_shots = self.get_num_shots()
+        if isinstance(num_shots, int):
+            shot_counts = [num_shots] * self.num_subtasks
+        else:
+            shot_counts = num_shots
+
+        if len(shot_counts) != self.num_subtasks:
+            raise ValueError(
+                f"Length mismatch: got {len(shot_counts)} shot counts for {self.num_subtasks} subtasks!"
+            )
 
         subtasks = []
         arguments = self.get_arguments()
@@ -251,7 +249,7 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
             subtasks.append(
                 Subtask(
                     program_index=self.program_index_for_subtask(i),
-                    num_shots=num_shots[i],
+                    num_shots=shot_counts[i],
                     arguments=args,
                     subtask_metadata=subtask_metadata,
                 )
@@ -268,8 +266,8 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
     def run_async(
         self,
         *,
-        dry_run: Literal[True],
-        shots: int | list[int] | None = None,
+        dry_run: Literal[True] = True,
+        shots: int | list[int] = 1,
         storage: StorageBackend | None = None,
         fetch_options: ApiFetchOptions = ApiFetchOptions(),
     ) -> None: ...
@@ -279,7 +277,7 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         self,
         *,
         dry_run: Literal[False],
-        shots: int | list[int] | None = None,
+        shots: int | list[int] = 1,
         storage: StorageBackend | None = None,
         fetch_options: ApiFetchOptions = ApiFetchOptions(),
     ) -> FutureType: ...
@@ -287,8 +285,8 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
     def run_async(
         self,
         *,
-        dry_run: bool,
-        shots: int | list[int] | None = None,
+        dry_run: bool = True,
+        shots: int | list[int] = 1,
         storage: StorageBackend | None = None,
         fetch_options: ApiFetchOptions = ApiFetchOptions(),
     ) -> FutureType | None:
@@ -296,11 +294,11 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
 
         Keyword Args:
             dry_run (bool): When True, print a summary and return None.
-                When False, submit the task and return a future.
-            shots (int | list[int] | None): Shot count applied to every
+                Defaults to True. When False, submit the task and return a
+                future.
+            shots (int | list[int]): Shot count applied to every
                 subtask, or one count per subtask, in the submitted QLAM task
-                definition. Pass None to preserve the shot counts configured
-                on the task. Defaults to None.
+                definition. Defaults to 1.
             storage (StorageBackend | None): Storage backend that will receive
                 the task definition and later fetched shots. When None, a fresh
                 `DictStorage` is used (in-memory; not persisted across
@@ -314,25 +312,11 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
                 `dry_run` is False; otherwise None.
 
         Raises:
-            ValueError: If argument or metadata lengths do not match
-                `num_subtasks`.
+            ValueError: If argument, metadata, or shot-count lengths do not
+                match `num_subtasks`.
         """
         self.validate_arguments()
-        task_def = self.create_task_definition()
-
-        if shots is not None:
-            if isinstance(shots, int):
-                shot_counts = [shots] * len(task_def.subtasks)
-            else:
-                shot_counts = shots
-
-            if len(shot_counts) != len(task_def.subtasks):
-                raise ValueError(
-                    f"Length mismatch: got {len(shot_counts)} shot counts for {len(task_def.subtasks)} subtasks!"
-                )
-
-            for subtask, shot_count in zip(task_def.subtasks, shot_counts):
-                subtask.num_shots = shot_count
+        task_def = self.create_task_definition(num_shots=shots)
 
         if dry_run:
             print(self.summary_for_task_definition(task_def))
@@ -408,15 +392,12 @@ class ParameterScanTask(TaskABC[FutureType]):
     Attributes:
         kernel (ir.Method): Kernel executed for each parameter set.
         arguments (list[dict]): Argument dictionaries, one per subtask.
-        num_shots (int | list[int]): Shot count per subtask, or one value
-            broadcast to every subtask.
         metadata (list[dict] | None): Per-subtask metadata. Defaults to
             None.
     """
 
     kernel: ir.Method
     arguments: list[dict]
-    num_shots: int | list[int]
     metadata: list[dict] | None = None
 
     @property
@@ -429,11 +410,6 @@ class ParameterScanTask(TaskABC[FutureType]):
 
     def get_arguments(self) -> list[dict]:
         return self.arguments
-
-    def get_num_shots(self) -> list[int]:
-        if isinstance(self.num_shots, int):
-            return [self.num_shots] * self.num_subtasks
-        return self.num_shots
 
     def get_metadata(self) -> list[dict] | None:
         return self.metadata
@@ -459,14 +435,12 @@ class SingleKernelTask(TaskABC[FutureType]):
         kernel (ir.Method): Kernel to execute.
         arguments (dict | None): Arguments for the kernel. Defaults to
             None.
-        num_shots (int): Shot count for the kernel.
         metadata (dict | None): Metadata for the single subtask. Defaults
             to None.
     """
 
     kernel: ir.Method
     arguments: dict | None = None
-    num_shots: int
     metadata: dict | None = None
 
     @property
@@ -480,14 +454,11 @@ class SingleKernelTask(TaskABC[FutureType]):
         if self.arguments is not None:
             return [self.arguments]
 
-    def get_num_shots(self) -> list[int]:
-        return [self.num_shots]
-
     def get_metadata(self) -> list[dict] | None:
         if self.metadata is not None:
             return [self.metadata]
 
-    def _summary(self, shots: int) -> str:
+    def _summary(self, shots: int | str) -> str:
         msg = "=" * 60 + "\n"
         msg += "DRY RUN -- NO PROGRAM WAS ACTUALLY SUBMITTED FOR EXECUTION\n"
         msg += "Would now submit a task containing a single subtask for the kernel:\n"
@@ -504,7 +475,7 @@ class SingleKernelTask(TaskABC[FutureType]):
         return msg
 
     def summary(self) -> str:
-        return self._summary(self.num_shots)
+        return self._summary(1)
 
     def summary_for_task_definition(self, task_definition: TaskDefinition) -> str:
         return self._summary(task_definition.subtasks[0].num_shots)
@@ -518,15 +489,12 @@ class KernelBatchTask(TaskABC[FutureType]):
         kernels (list[ir.Method]): Kernels to execute.
         arguments (list[dict] | None): Per-kernel argument dictionaries.
             Defaults to None.
-        num_shots (int | list[int]): Shot count per kernel, or one value
-            broadcast to every kernel.
         metadata (list[dict] | None): Per-kernel metadata. Defaults to
             None.
     """
 
     kernels: list[ir.Method]
     arguments: list[dict] | None = None
-    num_shots: int | list[int]
     metadata: list[dict] | None = None
 
     @property
@@ -539,15 +507,10 @@ class KernelBatchTask(TaskABC[FutureType]):
     def get_arguments(self) -> list[dict] | None:
         return self.arguments
 
-    def get_num_shots(self) -> list[int]:
-        if isinstance(self.num_shots, int):
-            return [self.num_shots] * self.num_subtasks
-        return self.num_shots
-
     def get_metadata(self) -> list[dict] | None:
         return self.metadata
 
-    def _summary(self, shot_counts: list[int]) -> str:
+    def _summary(self, shot_counts: list[int] | None) -> str:
         msg = "=" * 60 + "\n"
         msg += "DRY RUN -- NO PROGRAM WAS ACTUALLY SUBMITTED FOR EXECUTION\n"
         msg += f"Would now submit a task containing {len(self.kernels)} programs:\n"
@@ -557,13 +520,14 @@ class KernelBatchTask(TaskABC[FutureType]):
                 for arg in self.arguments[i]:
                     kernel_print += f"{arg}, "
             kernel_print += ")"
-            msg += f"  * {kernel_print} - {shot_counts[i]} shots\n"
+            shots = shot_counts[i] if shot_counts is not None else "unspecified"
+            msg += f"  * {kernel_print} - {shots} shots\n"
         msg += "Set dry_run=False to actually execute the programs.\n"
         msg += "=" * 60 + "\n"
         return msg
 
     def summary(self) -> str:
-        return self._summary(self.get_num_shots())
+        return self._summary([1] * self.num_subtasks)
 
     def summary_for_task_definition(self, task_definition: TaskDefinition) -> str:
         return self._summary(

--- a/src/bloqade/core/device/task.py
+++ b/src/bloqade/core/device/task.py
@@ -122,8 +122,17 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         """
         return f"Would now submit {self.num_subtasks} subtasks"
 
+    def summary_for_task_definition(self, task_definition: TaskDefinition) -> str:
+        """Return the dry-run summary for a prepared task definition.
+
+        Subclasses whose summary includes shot counts can override this method
+        to read the effective values from ``task_definition``. The default
+        preserves the existing ``summary`` extension point.
+        """
+        return self.summary()
+
     def validate_arguments(self) -> None:
-        """Validate that argument and metadata lengths match subtask count.
+        """Validate that task field lengths match the subtask count.
 
         Raises:
             ValueError: If arguments or metadata length differs from
@@ -229,7 +238,6 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         arguments = self.get_arguments()
         metadata = self.get_metadata()
         for i in range(self.num_subtasks):
-
             if arguments is not None:
                 args = arguments[i]
             else:
@@ -261,6 +269,7 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         self,
         *,
         dry_run: Literal[True],
+        shots: int | list[int] | None = None,
         storage: StorageBackend | None = None,
         fetch_options: ApiFetchOptions = ApiFetchOptions(),
     ) -> None: ...
@@ -270,6 +279,7 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         self,
         *,
         dry_run: Literal[False],
+        shots: int | list[int] | None = None,
         storage: StorageBackend | None = None,
         fetch_options: ApiFetchOptions = ApiFetchOptions(),
     ) -> FutureType: ...
@@ -278,6 +288,7 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         self,
         *,
         dry_run: bool,
+        shots: int | list[int] | None = None,
         storage: StorageBackend | None = None,
         fetch_options: ApiFetchOptions = ApiFetchOptions(),
     ) -> FutureType | None:
@@ -286,6 +297,10 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
         Keyword Args:
             dry_run (bool): When True, print a summary and return None.
                 When False, submit the task and return a future.
+            shots (int | list[int] | None): Shot count applied to every
+                subtask, or one count per subtask, in the submitted QLAM task
+                definition. Pass None to preserve the shot counts configured
+                on the task. Defaults to None.
             storage (StorageBackend | None): Storage backend that will receive
                 the task definition and later fetched shots. When None, a fresh
                 `DictStorage` is used (in-memory; not persisted across
@@ -303,11 +318,24 @@ class TaskABC(Generic[FutureType], AuthMixin, ABC):
                 `num_subtasks`.
         """
         self.validate_arguments()
-
         task_def = self.create_task_definition()
 
+        if shots is not None:
+            if isinstance(shots, int):
+                shot_counts = [shots] * len(task_def.subtasks)
+            else:
+                shot_counts = shots
+
+            if len(shot_counts) != len(task_def.subtasks):
+                raise ValueError(
+                    f"Length mismatch: got {len(shot_counts)} shot counts for {len(task_def.subtasks)} subtasks!"
+                )
+
+            for subtask, shot_count in zip(task_def.subtasks, shot_counts):
+                subtask.num_shots = shot_count
+
         if dry_run:
-            print(self.summary())
+            print(self.summary_for_task_definition(task_def))
             return
 
         return self.submit_task_definition(
@@ -459,7 +487,7 @@ class SingleKernelTask(TaskABC[FutureType]):
         if self.metadata is not None:
             return [self.metadata]
 
-    def summary(self) -> str:
+    def _summary(self, shots: int) -> str:
         msg = "=" * 60 + "\n"
         msg += "DRY RUN -- NO PROGRAM WAS ACTUALLY SUBMITTED FOR EXECUTION\n"
         msg += "Would now submit a task containing a single subtask for the kernel:\n"
@@ -470,11 +498,16 @@ class SingleKernelTask(TaskABC[FutureType]):
         else:
             formatted_arguments = ""
         kernel_print = f"{self.kernel.sym_name}({formatted_arguments})"
-        shots = self.num_shots if isinstance(self.num_shots, int) else self.num_shots[0]
         msg += f"  * {kernel_print} - {shots} shots\n"
         msg += "Set dry_run=False to actually execute this kernel.\n"
         msg += "=" * 60
         return msg
+
+    def summary(self) -> str:
+        return self._summary(self.num_shots)
+
+    def summary_for_task_definition(self, task_definition: TaskDefinition) -> str:
+        return self._summary(task_definition.subtasks[0].num_shots)
 
 
 @dataclass(kw_only=True)
@@ -514,7 +547,7 @@ class KernelBatchTask(TaskABC[FutureType]):
     def get_metadata(self) -> list[dict] | None:
         return self.metadata
 
-    def summary(self) -> str:
+    def _summary(self, shot_counts: list[int]) -> str:
         msg = "=" * 60 + "\n"
         msg += "DRY RUN -- NO PROGRAM WAS ACTUALLY SUBMITTED FOR EXECUTION\n"
         msg += f"Would now submit a task containing {len(self.kernels)} programs:\n"
@@ -524,10 +557,15 @@ class KernelBatchTask(TaskABC[FutureType]):
                 for arg in self.arguments[i]:
                     kernel_print += f"{arg}, "
             kernel_print += ")"
-            shots = (
-                self.num_shots if isinstance(self.num_shots, int) else self.num_shots[i]
-            )
-            msg += f"  * {kernel_print} - {shots} shots\n"
+            msg += f"  * {kernel_print} - {shot_counts[i]} shots\n"
         msg += "Set dry_run=False to actually execute the programs.\n"
         msg += "=" * 60 + "\n"
         return msg
+
+    def summary(self) -> str:
+        return self._summary(self.get_num_shots())
+
+    def summary_for_task_definition(self, task_definition: TaskDefinition) -> str:
+        return self._summary(
+            [subtask.num_shots for subtask in task_definition.subtasks]
+        )

--- a/test/device/test_device.py
+++ b/test/device/test_device.py
@@ -28,7 +28,6 @@ def test_device_task_builds_single_kernel_task_with_device_defaults():
 
     task = device.task(
         kernel,
-        num_shots=17,
         arguments={"theta": 1.5},
         metadata={"label": "calibration"},
         program_language="flair.v1",
@@ -38,7 +37,7 @@ def test_device_task_builds_single_kernel_task_with_device_defaults():
     assert task.context_name == "ctx"
     assert task.future_cls is CustomFuture
     assert task.kernel is kernel
-    assert task.num_shots == 17
+    assert not hasattr(task, "num_shots")
     assert task.arguments == {"theta": 1.5}
     assert task.metadata == {"label": "calibration"}
     assert task.program_language == "flair.v1"
@@ -61,7 +60,6 @@ def test_device_batch_task_builds_kernel_batch_task():
         kernels,
         arguments=[{"alpha": 0.25}, {"alpha": 0.5}],
         metadata=[{"name": "a"}, {"name": "b"}],
-        num_shots=[3, 5],
         program_language="squin",
     )
 
@@ -71,7 +69,7 @@ def test_device_batch_task_builds_kernel_batch_task():
     assert task.kernels == kernels
     assert task.arguments == [{"alpha": 0.25}, {"alpha": 0.5}]
     assert task.metadata == [{"name": "a"}, {"name": "b"}]
-    assert task.num_shots == [3, 5]
+    assert not hasattr(task, "num_shots")
     assert task.program_language == "squin"
     assert task.kernel_serializer is device.kernel_serializer
 
@@ -88,7 +86,6 @@ def test_device_parameter_scan_builds_parameter_scan_task():
         kernel,
         arguments=[{"detuning": -1.0}, {"detuning": 1.0}],
         metadata=[{"point": "left"}, {"point": "right"}],
-        num_shots=11,
         program_language="flair.v2",
     )
 
@@ -98,7 +95,7 @@ def test_device_parameter_scan_builds_parameter_scan_task():
     assert task.kernel is kernel
     assert task.arguments == [{"detuning": -1.0}, {"detuning": 1.0}]
     assert task.metadata == [{"point": "left"}, {"point": "right"}]
-    assert task.num_shots == 11
+    assert not hasattr(task, "num_shots")
     assert task.program_language == "flair.v2"
     assert task.kernel_serializer is device.kernel_serializer
 

--- a/test/device/test_task.py
+++ b/test/device/test_task.py
@@ -240,6 +240,7 @@ def test_run_async_dry_run_summary_uses_shot_override(monkeypatch, capsys):
         context_name="ctx",
         program_language="squin",
         kernel=main,
+        arguments={"theta": 1.5},
         num_shots=1,
     )
 
@@ -251,7 +252,55 @@ def test_run_async_dry_run_summary_uses_shot_override(monkeypatch, capsys):
 
     assert task.run_async(dry_run=True, shots=17) is None
 
-    assert "17 shots" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "theta=1.5" in output
+    assert "17 shots" in output
+    assert "1 shots" in task.summary()
+
+
+def test_parameter_scan_dry_run_uses_default_summary_for_task_definition(
+    monkeypatch, capsys
+):
+    task = ParameterScanTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=scan,
+        arguments=[{"x": 1.0}, {"x": 2.0}],
+        num_shots=[3, 5],
+    )
+
+    monkeypatch.setattr(
+        task,
+        "submit_task_definition",
+        lambda **kwargs: pytest.fail("dry runs should not submit"),
+    )
+
+    assert task.run_async(dry_run=True, shots=[17, 19]) is None
+
+    assert "parameter sets" in capsys.readouterr().out
+
+
+def test_batch_task_dry_run_summary_uses_per_subtask_shot_override(monkeypatch, capsys):
+    task = KernelBatchTask(
+        context_name="ctx",
+        program_language="squin",
+        kernels=[first, second],
+        arguments=[{"theta": 1.5}, {"phi": 0.5}],
+        num_shots=1,
+    )
+
+    monkeypatch.setattr(
+        task,
+        "submit_task_definition",
+        lambda **kwargs: pytest.fail("dry runs should not submit"),
+    )
+
+    assert task.run_async(dry_run=True, shots=[17, 19]) is None
+
+    output = capsys.readouterr().out
+    assert "17 shots" in output
+    assert "19 shots" in output
+    assert "1 shots" in task.summary()
 
 
 def test_run_async_submits_created_task_definition(monkeypatch):

--- a/test/device/test_task.py
+++ b/test/device/test_task.py
@@ -235,6 +235,25 @@ def test_run_async_dry_run_prints_summary_and_does_not_submit(monkeypatch, capsy
     assert "main(" in output
 
 
+def test_run_async_dry_run_summary_uses_shot_override(monkeypatch, capsys):
+    task = SingleKernelTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=main,
+        num_shots=1,
+    )
+
+    monkeypatch.setattr(
+        task,
+        "submit_task_definition",
+        lambda **kwargs: pytest.fail("dry runs should not submit"),
+    )
+
+    assert task.run_async(dry_run=True, shots=17) is None
+
+    assert "17 shots" in capsys.readouterr().out
+
+
 def test_run_async_submits_created_task_definition(monkeypatch):
     task = SingleKernelTask(
         context_name="ctx",
@@ -263,6 +282,138 @@ def test_run_async_submits_created_task_definition(monkeypatch):
     )
     assert submitted["storage"] is storage
     assert submitted["fetch_options"] is fetch_options
+
+
+def test_run_async_overrides_every_subtask_shot_count(monkeypatch):
+    task = KernelBatchTask(
+        context_name="ctx",
+        program_language="squin",
+        kernels=[first, second],
+        num_shots=[3, 5],
+    )
+    submitted = {}
+    sentinel = object()
+
+    def submit_task_definition(**kwargs):
+        submitted.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
+
+    assert task.run_async(dry_run=False, shots=17) is sentinel
+    assert [subtask.num_shots for subtask in submitted["task_definition"].subtasks] == [
+        17,
+        17,
+    ]
+    assert task.num_shots == [3, 5]
+
+
+def test_run_async_supports_legacy_create_task_definition_override(monkeypatch):
+    class CustomSingleKernelTask(SingleKernelTask):
+        def create_task_definition(self):
+            return super().create_task_definition()
+
+    task = CustomSingleKernelTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=main,
+        num_shots=3,
+    )
+    submitted = {}
+    sentinel = object()
+
+    def submit_task_definition(**kwargs):
+        submitted.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
+
+    assert task.run_async(dry_run=False, shots=17) is sentinel
+    assert submitted["task_definition"].subtasks[0].num_shots == 17
+
+
+def test_run_async_accepts_per_subtask_shot_counts(monkeypatch):
+    task = KernelBatchTask(
+        context_name="ctx",
+        program_language="squin",
+        kernels=[first, second],
+        num_shots=1,
+    )
+    submitted = {}
+    sentinel = object()
+
+    def submit_task_definition(**kwargs):
+        submitted.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
+
+    assert task.run_async(dry_run=False, shots=[17, 19]) is sentinel
+    assert [subtask.num_shots for subtask in submitted["task_definition"].subtasks] == [
+        17,
+        19,
+    ]
+
+
+def test_run_async_defaults_to_stored_shot_count(monkeypatch):
+    task = SingleKernelTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=main,
+        num_shots=23,
+    )
+    submitted = {}
+    sentinel = object()
+
+    def submit_task_definition(**kwargs):
+        submitted.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
+
+    assert task.run_async(dry_run=False) is sentinel
+    assert submitted["task_definition"].subtasks[0].num_shots == 23
+
+
+def test_run_async_with_none_uses_stored_shot_counts(monkeypatch):
+    task = KernelBatchTask(
+        context_name="ctx",
+        program_language="squin",
+        kernels=[first, second],
+        num_shots=[3, 5],
+    )
+    submitted = {}
+    sentinel = object()
+
+    def submit_task_definition(**kwargs):
+        submitted.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
+
+    assert task.run_async(dry_run=False, shots=None) is sentinel
+    assert [subtask.num_shots for subtask in submitted["task_definition"].subtasks] == [
+        3,
+        5,
+    ]
+
+
+def test_run_async_rejects_shot_override_length_mismatch(monkeypatch):
+    task = KernelBatchTask(
+        context_name="ctx",
+        program_language="squin",
+        kernels=[first, second],
+        num_shots=[3, 5],
+    )
+
+    monkeypatch.setattr(
+        task,
+        "submit_task_definition",
+        lambda **kwargs: pytest.fail("invalid overrides should not submit"),
+    )
+
+    with pytest.raises(ValueError, match="1 shot counts for 2 subtasks"):
+        task.run_async(dry_run=False, shots=[17])
 
 
 def test_submit_task_definition_stores_definition_and_returns_future(monkeypatch):

--- a/test/device/test_task.py
+++ b/test/device/test_task.py
@@ -61,10 +61,9 @@ def test_single_kernel_task_creates_task_definition_with_arguments_and_metadata(
         kernel=main,
         arguments={"theta": 1.5},
         metadata={"purpose": "unit-test"},
-        num_shots=23,
     )
 
-    task_definition = task.create_task_definition()
+    task_definition = task.create_task_definition(num_shots=23)
 
     assert task_definition.program_language == "flair.v1"
     assert len(task_definition.subtasks) == 1
@@ -78,18 +77,28 @@ def test_single_kernel_task_creates_task_definition_with_arguments_and_metadata(
     )
 
 
+def test_create_task_definition_requires_shot_count():
+    task = SingleKernelTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=main,
+    )
+
+    with pytest.raises(TypeError, match="num_shots"):
+        task.create_task_definition()  # type: ignore[call-arg]
+
+
 def test_single_kernel_task_omits_arguments_and_metadata_when_unset():
     task = SingleKernelTask(
         context_name="ctx",
         program_language="squin",
         kernel=main,
-        num_shots=1,
     )
 
     assert task.get_arguments() is None
     assert task.get_metadata() is None
 
-    subtask = task.create_task_definition().subtasks[0]
+    subtask = task.create_task_definition(num_shots=1).subtasks[0]
     assert subtask.arguments is None
     assert subtask.subtask_metadata is None
 
@@ -99,10 +108,9 @@ def test_single_kernel_task_serializes_kernel_with_json_by_default():
         context_name="ctx",
         program_language="squin",
         kernel=main,
-        num_shots=1,
     )
 
-    content = task.create_task_definition().programs[0].content
+    content = task.create_task_definition(num_shots=1).programs[0].content
     encoded_module = main.dialects.encode(main, version=task.program_language_version)
 
     assert content == JSONSerializer().encode(encoded_module)
@@ -114,11 +122,10 @@ def test_single_kernel_task_base64_encodes_binary_serializer_output():
         context_name="ctx",
         program_language="flair",
         kernel=main,
-        num_shots=1,
         kernel_serializer=CompressedBSONSerializer(),
     )
 
-    content = task.create_task_definition().programs[0].content
+    content = task.create_task_definition(num_shots=1).programs[0].content
     decoded_module = CompressedBSONSerializer().decode(
         base64.b64decode(content, validate=True)
     )
@@ -136,7 +143,6 @@ def test_single_kernel_task_rejects_non_string_serializer_output():
         context_name="ctx",
         program_language="squin",
         kernel=main,
-        num_shots=1,
         kernel_serializer=cast(KernelSerializer, DictSerializer()),
     )
 
@@ -151,10 +157,9 @@ def test_parameter_scan_reuses_one_program_for_all_argument_sets():
         kernel=scan,
         arguments=[{"x": 1.0}, {"x": 2.0}, {"x": 3.0}],
         metadata=[{"i": 0}, {"i": 1}, {"i": 2}],
-        num_shots=7,
     )
 
-    task_definition = task.create_task_definition()
+    task_definition = task.create_task_definition(num_shots=7)
 
     assert [subtask.program_index for subtask in task_definition.subtasks] == [0, 0, 0]
     assert [subtask.num_shots for subtask in task_definition.subtasks] == [7, 7, 7]
@@ -176,10 +181,9 @@ def test_kernel_batch_task_maps_each_kernel_to_its_own_program():
         program_language="squin",
         kernels=[first, second],
         arguments=[{"x": 1.0}, {"x": 2.0}],
-        num_shots=[3, 5],
     )
 
-    task_definition = task.create_task_definition()
+    task_definition = task.create_task_definition(num_shots=[3, 5])
 
     assert [subtask.program_index for subtask in task_definition.subtasks] == [0, 1]
     assert [subtask.num_shots for subtask in task_definition.subtasks] == [3, 5]
@@ -196,23 +200,21 @@ def test_validate_arguments_rejects_metadata_length_mismatch():
         kernel=scan,
         arguments=[{"x": 1.0}, {"x": 2.0}],
         metadata=[{"only": "one"}],
-        num_shots=7,
     )
 
     with pytest.raises(ValueError, match="1 sets of metadata for 2 subtasks"):
         task.validate_arguments()
 
 
-def test_validate_arguments_rejects_shot_count_length_mismatch():
+def test_create_task_definition_rejects_shot_count_length_mismatch():
     task = KernelBatchTask(
         context_name="ctx",
         program_language="squin",
         kernels=[first, second],
-        num_shots=[3],
     )
 
     with pytest.raises(ValueError, match="1 shot counts for 2 subtasks"):
-        task.validate_arguments()
+        task.create_task_definition(num_shots=[3])
 
 
 def test_run_async_dry_run_prints_summary_and_does_not_submit(monkeypatch, capsys):
@@ -220,7 +222,6 @@ def test_run_async_dry_run_prints_summary_and_does_not_submit(monkeypatch, capsy
         context_name="ctx",
         program_language="squin",
         kernel=main,
-        num_shots=1,
     )
 
     def fail_if_submitted(**kwargs):
@@ -235,13 +236,67 @@ def test_run_async_dry_run_prints_summary_and_does_not_submit(monkeypatch, capsy
     assert "main(" in output
 
 
+def test_run_async_defaults_to_dry_run_with_one_shot(monkeypatch, capsys):
+    task = SingleKernelTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=main,
+    )
+
+    monkeypatch.setattr(
+        task,
+        "submit_task_definition",
+        lambda **kwargs: pytest.fail("dry runs should not submit"),
+    )
+
+    assert task.run_async() is None
+    assert "1 shots" in capsys.readouterr().out
+
+
+def test_run_async_defaults_to_one_shot_on_submission(monkeypatch):
+    task = SingleKernelTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=main,
+    )
+    submitted = {}
+    sentinel = object()
+
+    def submit_task_definition(**kwargs):
+        submitted.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
+
+    assert task.run_async(dry_run=False) is sentinel
+    assert submitted["task_definition"].subtasks[0].num_shots == 1
+
+
+def test_run_async_submits_unconfigured_task_with_shots(monkeypatch):
+    task = SingleKernelTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=main,
+    )
+    submitted = {}
+    sentinel = object()
+
+    def submit_task_definition(**kwargs):
+        submitted.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
+
+    assert task.run_async(dry_run=False, shots=17) is sentinel
+    assert submitted["task_definition"].subtasks[0].num_shots == 17
+
+
 def test_run_async_dry_run_summary_uses_shot_override(monkeypatch, capsys):
     task = SingleKernelTask(
         context_name="ctx",
         program_language="squin",
         kernel=main,
         arguments={"theta": 1.5},
-        num_shots=1,
     )
 
     monkeypatch.setattr(
@@ -266,7 +321,6 @@ def test_parameter_scan_dry_run_uses_default_summary_for_task_definition(
         program_language="squin",
         kernel=scan,
         arguments=[{"x": 1.0}, {"x": 2.0}],
-        num_shots=[3, 5],
     )
 
     monkeypatch.setattr(
@@ -286,7 +340,6 @@ def test_batch_task_dry_run_summary_uses_per_subtask_shot_override(monkeypatch, 
         program_language="squin",
         kernels=[first, second],
         arguments=[{"theta": 1.5}, {"phi": 0.5}],
-        num_shots=1,
     )
 
     monkeypatch.setattr(
@@ -308,7 +361,6 @@ def test_run_async_submits_created_task_definition(monkeypatch):
         context_name="ctx",
         program_language="squin",
         kernel=main,
-        num_shots=1,
     )
     storage = DictStorage()
     fetch_options = ApiFetchOptions(shots_per_fetch=5)
@@ -324,6 +376,7 @@ def test_run_async_submits_created_task_definition(monkeypatch):
     assert (
         task.run_async(
             dry_run=False,
+            shots=1,
             storage=storage,
             fetch_options=fetch_options,
         )
@@ -333,12 +386,11 @@ def test_run_async_submits_created_task_definition(monkeypatch):
     assert submitted["fetch_options"] is fetch_options
 
 
-def test_run_async_overrides_every_subtask_shot_count(monkeypatch):
+def test_run_async_default_shots_broadcast_to_every_batch_subtask(monkeypatch):
     task = KernelBatchTask(
         context_name="ctx",
         program_language="squin",
         kernels=[first, second],
-        num_shots=[3, 5],
     )
     submitted = {}
     sentinel = object()
@@ -349,24 +401,47 @@ def test_run_async_overrides_every_subtask_shot_count(monkeypatch):
 
     monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
 
-    assert task.run_async(dry_run=False, shots=17) is sentinel
+    assert task.run_async(dry_run=False) is sentinel
     assert [subtask.num_shots for subtask in submitted["task_definition"].subtasks] == [
-        17,
-        17,
+        1,
+        1,
     ]
-    assert task.num_shots == [3, 5]
 
 
-def test_run_async_supports_legacy_create_task_definition_override(monkeypatch):
+def test_run_async_default_shots_broadcast_to_every_parameter_scan_subtask(
+    monkeypatch,
+):
+    task = ParameterScanTask(
+        context_name="ctx",
+        program_language="squin",
+        kernel=scan,
+        arguments=[{"x": 1.0}, {"x": 2.0}],
+    )
+    submitted = {}
+    sentinel = object()
+
+    def submit_task_definition(**kwargs):
+        submitted.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
+
+    assert task.run_async(dry_run=False) is sentinel
+    assert [subtask.num_shots for subtask in submitted["task_definition"].subtasks] == [
+        1,
+        1,
+    ]
+
+
+def test_run_async_supports_create_task_definition_override(monkeypatch):
     class CustomSingleKernelTask(SingleKernelTask):
-        def create_task_definition(self):
-            return super().create_task_definition()
+        def create_task_definition(self, *, num_shots: int | list[int]):
+            return super().create_task_definition(num_shots=num_shots)
 
     task = CustomSingleKernelTask(
         context_name="ctx",
         program_language="squin",
         kernel=main,
-        num_shots=3,
     )
     submitted = {}
     sentinel = object()
@@ -386,7 +461,6 @@ def test_run_async_accepts_per_subtask_shot_counts(monkeypatch):
         context_name="ctx",
         program_language="squin",
         kernels=[first, second],
-        num_shots=1,
     )
     submitted = {}
     sentinel = object()
@@ -404,55 +478,11 @@ def test_run_async_accepts_per_subtask_shot_counts(monkeypatch):
     ]
 
 
-def test_run_async_defaults_to_stored_shot_count(monkeypatch):
-    task = SingleKernelTask(
-        context_name="ctx",
-        program_language="squin",
-        kernel=main,
-        num_shots=23,
-    )
-    submitted = {}
-    sentinel = object()
-
-    def submit_task_definition(**kwargs):
-        submitted.update(kwargs)
-        return sentinel
-
-    monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
-
-    assert task.run_async(dry_run=False) is sentinel
-    assert submitted["task_definition"].subtasks[0].num_shots == 23
-
-
-def test_run_async_with_none_uses_stored_shot_counts(monkeypatch):
-    task = KernelBatchTask(
-        context_name="ctx",
-        program_language="squin",
-        kernels=[first, second],
-        num_shots=[3, 5],
-    )
-    submitted = {}
-    sentinel = object()
-
-    def submit_task_definition(**kwargs):
-        submitted.update(kwargs)
-        return sentinel
-
-    monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
-
-    assert task.run_async(dry_run=False, shots=None) is sentinel
-    assert [subtask.num_shots for subtask in submitted["task_definition"].subtasks] == [
-        3,
-        5,
-    ]
-
-
 def test_run_async_rejects_shot_override_length_mismatch(monkeypatch):
     task = KernelBatchTask(
         context_name="ctx",
         program_language="squin",
         kernels=[first, second],
-        num_shots=[3, 5],
     )
 
     monkeypatch.setattr(
@@ -470,12 +500,11 @@ def test_submit_task_definition_stores_definition_and_returns_future(monkeypatch
         context_name="ctx",
         program_language="squin",
         kernel=main,
-        num_shots=1,
         future_cls=RecordingFuture,  # type: ignore
     )
     storage = DictStorage()
     fetch_options = ApiFetchOptions(subtasks_per_fetch=2)
-    task_definition = task.create_task_definition()
+    task_definition = task.create_task_definition(num_shots=1)
     calls = {"authenticated": False}
 
     created_task = remote.make_task(
@@ -512,7 +541,6 @@ def test_run_async_defaults_storage_to_fresh_dict_storage(monkeypatch):
         context_name="ctx",
         program_language="squin",
         kernel=main,
-        num_shots=1,
     )
     submitted = {}
     sentinel = object()
@@ -523,7 +551,7 @@ def test_run_async_defaults_storage_to_fresh_dict_storage(monkeypatch):
 
     monkeypatch.setattr(task, "submit_task_definition", submit_task_definition)
 
-    assert task.run_async(dry_run=False) is sentinel
+    assert task.run_async(dry_run=False, shots=1) is sentinel
     assert submitted["storage"] is None
 
 
@@ -532,10 +560,9 @@ def test_submit_task_definition_defaults_to_fresh_dict_storage(monkeypatch):
         context_name="ctx",
         program_language="squin",
         kernel=main,
-        num_shots=1,
         future_cls=RecordingFuture,  # type: ignore
     )
-    task_definition = task.create_task_definition()
+    task_definition = task.create_task_definition(num_shots=1)
 
     created_task = remote.make_task(
         id="task-created",
@@ -559,7 +586,6 @@ def test_submit_task_definition_rejects_missing_created_task_id(monkeypatch):
         context_name="ctx",
         program_language="squin",
         kernel=main,
-        num_shots=1,
     )
 
     created_task = remote.make_task(
@@ -574,7 +600,7 @@ def test_submit_task_definition_rejects_missing_created_task_id(monkeypatch):
 
     with pytest.raises(ValueError, match="Couldn't get id of created task"):
         task.submit_task_definition(
-            task_definition=task.create_task_definition(),
+            task_definition=task.create_task_definition(num_shots=1),
             storage=DictStorage(),
         )
 
@@ -584,10 +610,9 @@ def test_submit_task_definition_retries_on_403_after_refresh(monkeypatch):
         context_name="ctx",
         program_language="squin",
         kernel=main,
-        num_shots=1,
         future_cls=RecordingFuture,  # type: ignore
     )
-    task_definition = task.create_task_definition()
+    task_definition = task.create_task_definition(num_shots=1)
     created_task = remote.make_task(
         id="task-x",
         task_status=TaskStatus.CREATED,


### PR DESCRIPTION
closes https://github.com/QuEraComputing/bloqade-internal/issues/398

Nonbreaking change to pass in "shots" argument to "run_async".
- Sets the "shots" value in the TaskDefinition to whatever the user inputs via "run_async" (instead of the stored shots on the task)
- Overrides/updates the dry-run printing for the summary.
## BREAKING CHANGES
- Gets rid of "num_shots" from device.task() and from storing it on the tasks. (This changes some public API's)
- Have "dry_run" default to True.


# Summary

Move shot-count configuration from task creation to execution. Tasks no longer
store shot counts; `run_async()` supplies them when it builds the QLAM task
definition.

- `TaskABC.run_async()` now defaults to a one-shot dry run.
- `shots: int | list[int] = 1` controls the QLAM subtask counts.
- An integer broadcasts to every subtask; a list supplies one count per
  subtask.
- Direct QLAM definition creation requires an explicit `num_shots` value.

# Breaking changes

## Task factories no longer accept `num_shots`

Remove `num_shots` from all task factories:

- `Device.task(...)`
- `Device.batch_task(...)`
- `Device.parameter_scan(...)`

Before:

```python
task = device.batch_task(kernels, num_shots=100)
future = task.run_async(dry_run=False)
```

After:

```python
task = device.batch_task(kernels)
future = task.run_async(dry_run=False, shots=100)
```

For per-subtask counts, pass a list when running:

```python
future = task.run_async(dry_run=False, shots=[100, 200])
```

## Task objects no longer store shot counts

`SingleKernelTask`, `KernelBatchTask`, and `ParameterScanTask` no longer have
a `num_shots` field, and `TaskABC.get_num_shots()` has been removed. Code that
reads or mutates those fields must instead provide `shots` to `run_async()` or
`num_shots` to `create_task_definition()`.

## `run_async()` now defaults to a dry run and one shot

The new signature is:

```python
task.run_async(*, dry_run: bool = True, shots: int | list[int] = 1)
```

Consequences:

- `task.run_async()` now prints a one-shot dry-run summary and returns `None`.
- Calls that are intended to submit must continue to pass `dry_run=False`.
- `task.run_async(dry_run=False)` submits one shot per subtask unless `shots`
  is explicitly supplied.
- `shots=None` is no longer supported.

## `create_task_definition()` requires `num_shots`

The new signature is:

```python
task.create_task_definition(*, num_shots: int | list[int])
```

Custom `TaskABC` subclasses that override this method must update their
override to accept and use that keyword argument.

# Implementation details

- Every QLAM `Subtask` is created with a concrete shot count.
- Per-subtask shot-count lists are validated against the number of subtasks
  and raise a clear `ValueError` when lengths differ.
- Single-kernel and batch summaries show the effective shot counts, including
  the default of one shot.

# Testing

- `uv run pytest` — 262 passed
- `uv run ruff check .`
- `uv run pyright`
- `uv run just coverage` — 95% total coverage
